### PR TITLE
docs: Add XML documentation to public API surface

### DIFF
--- a/src/BlogDoFT.Libs.Api.OpenTelemetry/Extensions/OpenTelemetryExtension.cs
+++ b/src/BlogDoFT.Libs.Api.OpenTelemetry/Extensions/OpenTelemetryExtension.cs
@@ -15,8 +15,18 @@ using System.Diagnostics.Metrics;
 
 namespace BlogDoFT.Libs.Api.OpenTelemetry.Extensions;
 
+/// <summary>
+/// Provides extension methods to register and enable OpenTelemetry instrumentation for metrics, tracing and logs.
+/// </summary>
 public static class OpenTelemetryExtension
 {
+    /// <summary>
+    /// Registers OpenTelemetry services (metrics, tracing and logs) based on the <c>Observability</c> section of
+    /// <paramref name="configuration"/>. If that section is not present, no OpenTelemetry services are registered.
+    /// </summary>
+    /// <param name="services">The service collection to add the OpenTelemetry services to.</param>
+    /// <param name="configuration">The application configuration used to build the <see cref="Observability"/> settings.</param>
+    /// <returns>The same <paramref name="services"/> instance, for chaining.</returns>
     public static IServiceCollection AddOtel(this IServiceCollection services, IConfiguration configuration)
     {
         var hasObservability = configuration.GetSection(nameof(Observability)).Exists();
@@ -39,6 +49,12 @@ public static class OpenTelemetryExtension
             .Services;
     }
 
+    /// <summary>
+    /// Maps the Prometheus scraping endpoint when the registered <see cref="Observability"/> configuration
+    /// selects Prometheus as the metrics exporter.
+    /// </summary>
+    /// <param name="app">The application builder to configure.</param>
+    /// <returns>The same <paramref name="app"/> instance, for chaining.</returns>
     public static IApplicationBuilder UseOpenTelemetry(this IApplicationBuilder app)
     {
         var observability = app.ApplicationServices.GetRequiredService<IOptions<Observability>>().Value;

--- a/src/BlogDoFT.Libs.Api.OpenTelemetry/ObservabilityConfig/AspNetCoreInstrumentation.cs
+++ b/src/BlogDoFT.Libs.Api.OpenTelemetry/ObservabilityConfig/AspNetCoreInstrumentation.cs
@@ -2,12 +2,24 @@ using Microsoft.Extensions.Configuration;
 
 namespace BlogDoFT.Libs.Api.OpenTelemetry.ObservabilityConfig;
 
+/// <summary>
+/// Configuration options for the ASP.NET Core instrumentation used by OpenTelemetry tracing.
+/// </summary>
 public class AspNetCoreInstrumentation
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AspNetCoreInstrumentation"/> class from the given
+    /// configuration section.
+    /// </summary>
+    /// <param name="section">The configuration section containing the ASP.NET Core instrumentation settings.</param>
     public AspNetCoreInstrumentation(IConfigurationSection section)
     {
         RecordException = section.GetValue(nameof(RecordException), true);
     }
 
+    /// <summary>
+    /// Gets a value indicating whether unhandled exceptions should be recorded on the trace activity.
+    /// Defaults to <see langword="true"/> when not configured.
+    /// </summary>
     public bool RecordException { get; }
 }

--- a/src/BlogDoFT.Libs.Api.OpenTelemetry/ObservabilityConfig/HistogramOptions.cs
+++ b/src/BlogDoFT.Libs.Api.OpenTelemetry/ObservabilityConfig/HistogramOptions.cs
@@ -1,5 +1,8 @@
 namespace BlogDoFT.Libs.Api.OpenTelemetry.ObservabilityConfig;
 
+/// <summary>
+/// Defines the bucketing strategy used for histogram metrics.
+/// </summary>
 public enum HistogramOptions
 {
     /// <summary>

--- a/src/BlogDoFT.Libs.Api.OpenTelemetry/ObservabilityConfig/LogExporterOptions.cs
+++ b/src/BlogDoFT.Libs.Api.OpenTelemetry/ObservabilityConfig/LogExporterOptions.cs
@@ -1,5 +1,8 @@
 namespace BlogDoFT.Libs.Api.OpenTelemetry.ObservabilityConfig;
 
+/// <summary>
+/// Defines the destination used to export log records.
+/// </summary>
 public enum LogExporterOptions
 {
     /// <summary>

--- a/src/BlogDoFT.Libs.Api.OpenTelemetry/ObservabilityConfig/MetricsExporterOptions.cs
+++ b/src/BlogDoFT.Libs.Api.OpenTelemetry/ObservabilityConfig/MetricsExporterOptions.cs
@@ -1,5 +1,8 @@
 namespace BlogDoFT.Libs.Api.OpenTelemetry.ObservabilityConfig;
 
+/// <summary>
+/// Defines the destination used to export metrics.
+/// </summary>
 public enum MetricsExporterOptions
 {
     /// <summary>

--- a/src/BlogDoFT.Libs.Api.OpenTelemetry/ObservabilityConfig/Observability.cs
+++ b/src/BlogDoFT.Libs.Api.OpenTelemetry/ObservabilityConfig/Observability.cs
@@ -3,8 +3,17 @@ using OpenTelemetry.Exporter;
 
 namespace BlogDoFT.Libs.Api.OpenTelemetry.ObservabilityConfig;
 
+/// <summary>
+/// Root configuration for OpenTelemetry observability, read from the <c>Observability</c> section of the
+/// application configuration.
+/// </summary>
 public class Observability
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Observability"/> class, reading its nested sections
+    /// (OpenTelemetry, Zipkin, OTLP, ASP.NET Core instrumentation and Prometheus) from <paramref name="configuration"/>.
+    /// </summary>
+    /// <param name="configuration">The application configuration containing the <c>Observability</c> section.</param>
     public Observability(IConfiguration configuration)
     {
         var openTelemetrySection = configuration
@@ -27,13 +36,28 @@ public class Observability
             .Get<PrometheusAspNetCoreOptions>();
     }
 
+    /// <summary>
+    /// Gets or sets the general OpenTelemetry settings (exporters, aggregation, active signals).
+    /// </summary>
     public OpenTelemetry OpenTelemetry { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Zipkin exporter options, or <see langword="null"/> when not configured.
+    /// </summary>
     public ZipkinExporterOptions? ZipkinExporterOptions { get; set; }
 
+    /// <summary>
+    /// Gets or sets the OTLP exporter options, or <see langword="null"/> when not configured.
+    /// </summary>
     public OtlpExporterOptions? OtlpExporterOptions { get; set; }
 
+    /// <summary>
+    /// Gets or sets the ASP.NET Core instrumentation options.
+    /// </summary>
     public AspNetCoreInstrumentation AspNetCoreInstrumentation { get; set; }
 
+    /// <summary>
+    /// Gets or sets the Prometheus ASP.NET Core exporter options, or <see langword="null"/> when not configured.
+    /// </summary>
     public PrometheusAspNetCoreOptions? PrometheusAspNetCoreOptions { get; set; }
 }

--- a/src/BlogDoFT.Libs.Api.OpenTelemetry/ObservabilityConfig/OpenTelemetry.cs
+++ b/src/BlogDoFT.Libs.Api.OpenTelemetry/ObservabilityConfig/OpenTelemetry.cs
@@ -2,8 +2,16 @@ using Microsoft.Extensions.Configuration;
 
 namespace BlogDoFT.Libs.Api.OpenTelemetry.ObservabilityConfig;
 
+/// <summary>
+/// General OpenTelemetry settings controlling which signals (tracing, metrics, logs) are active and which
+/// exporters and aggregation strategy they use.
+/// </summary>
 public class OpenTelemetry
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OpenTelemetry"/> class from the given configuration section.
+    /// </summary>
+    /// <param name="section">The configuration section containing the OpenTelemetry settings.</param>
     public OpenTelemetry(IConfigurationSection section)
     {
         IncludeFormattedMessage = section.GetValue(nameof(IncludeFormattedMessage), true);
@@ -15,23 +23,59 @@ public class OpenTelemetry
         HistogramAggregation = section.GetValue<HistogramOptions>(nameof(HistogramAggregation));
     }
 
+    /// <summary>
+    /// Gets a value indicating whether the formatted log message should be included in log records.
+    /// Defaults to <see langword="true"/> when not configured.
+    /// </summary>
     public bool IncludeFormattedMessage { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether logging scopes should be included in log records.
+    /// Defaults to <see langword="true"/> when not configured.
+    /// </summary>
     public bool IncludeScopes { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether structured log state values should be parsed.
+    /// Defaults to <see langword="true"/> when not configured.
+    /// </summary>
     public bool ParseStateValues { get; init; }
 
+    /// <summary>
+    /// Gets the exporter used for tracing.
+    /// </summary>
     public TracingExporterOptions UseTracingExporter { get; init; }
 
+    /// <summary>
+    /// Gets the exporter used for metrics.
+    /// </summary>
     public MetricsExporterOptions UseMetricsExporter { get; init; }
 
+    /// <summary>
+    /// Gets the exporter used for logs.
+    /// </summary>
     public LogExporterOptions UseLogExporter { get; init; }
 
+    /// <summary>
+    /// Gets the bucketing strategy used for histogram metrics.
+    /// </summary>
     public HistogramOptions HistogramAggregation { get; init; }
 
+    /// <summary>
+    /// Gets a value indicating whether tracing is active, i.e. <see cref="UseTracingExporter"/> is not
+    /// <see cref="TracingExporterOptions.DoNotUse"/>.
+    /// </summary>
     public bool TracingActive => UseTracingExporter != TracingExporterOptions.DoNotUse;
 
+    /// <summary>
+    /// Gets a value indicating whether metrics collection is active, i.e. <see cref="UseMetricsExporter"/> is not
+    /// <see cref="MetricsExporterOptions.DoNotUse"/>.
+    /// </summary>
     public bool MetricsActive => UseMetricsExporter != MetricsExporterOptions.DoNotUse;
 
+    /// <summary>
+    /// Gets a value indicating whether log exporting is active, i.e. <see cref="UseLogExporter"/> is not
+    /// <see cref="LogExporterOptions.DotNotUse"/>.
+    /// </summary>
     public bool LogsActive => UseLogExporter != LogExporterOptions.DotNotUse;
 }

--- a/src/BlogDoFT.Libs.Api.OpenTelemetry/ObservabilityConfig/Otlp.cs
+++ b/src/BlogDoFT.Libs.Api.OpenTelemetry/ObservabilityConfig/Otlp.cs
@@ -1,6 +1,12 @@
 namespace BlogDoFT.Libs.Api.OpenTelemetry.ObservabilityConfig;
 
+/// <summary>
+/// Configuration for an OTLP (OpenTelemetry Protocol) endpoint.
+/// </summary>
 public class Otlp
 {
+    /// <summary>
+    /// Gets or sets the OTLP collector endpoint.
+    /// </summary>
     public Uri Endpoint { get; set; } = null!;
 }

--- a/src/BlogDoFT.Libs.Api.OpenTelemetry/ObservabilityConfig/TracingExporterOptions.cs
+++ b/src/BlogDoFT.Libs.Api.OpenTelemetry/ObservabilityConfig/TracingExporterOptions.cs
@@ -1,5 +1,8 @@
 namespace BlogDoFT.Libs.Api.OpenTelemetry.ObservabilityConfig;
 
+/// <summary>
+/// Defines the destination used to export trace data.
+/// </summary>
 public enum TracingExporterOptions
 {
     /// <summary>

--- a/src/BlogDoFT.Libs.Api.OpenTelemetry/ObservabilityConfig/Zipkin.cs
+++ b/src/BlogDoFT.Libs.Api.OpenTelemetry/ObservabilityConfig/Zipkin.cs
@@ -1,6 +1,12 @@
 namespace BlogDoFT.Libs.Api.OpenTelemetry.ObservabilityConfig;
 
+/// <summary>
+/// Configuration for a Zipkin exporter endpoint.
+/// </summary>
 public class Zipkin
 {
+    /// <summary>
+    /// Gets or sets the Zipkin collector endpoint.
+    /// </summary>
     public Uri Endpoint { get; set; } = null!;
 }

--- a/src/BlogDoFT.Libs.Api/Extensions/HttpHeaderExtension.cs
+++ b/src/BlogDoFT.Libs.Api/Extensions/HttpHeaderExtension.cs
@@ -3,6 +3,9 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace BlogDoFT.Libs.Api.Extensions;
 
+/// <summary>
+/// Provides extension methods for reading well-known values from HTTP request headers.
+/// </summary>
 [ExcludeFromCodeCoverage]
 public static class HttpHeaderExtension
 {
@@ -10,6 +13,11 @@ public static class HttpHeaderExtension
     private const string ForwardedHost = "X-Forwarded-Host";
     private const string AcceptLanguageHeader = "Accept-Language";
 
+    /// <summary>
+    /// Gets the correlation id from the <c>X-Correlation-ID</c> header, generating a new one if it is missing or empty.
+    /// </summary>
+    /// <param name="headers">The header collection to read from.</param>
+    /// <returns>The correlation id found in the headers, or a newly generated <see cref="Guid"/> as a string when none is present.</returns>
     public static string GetCorrelationId(this IHeaderDictionary headers)
     {
         var hasCorrelationId = headers.TryGetValue(CorrelationId, out var headerValue);
@@ -22,6 +30,11 @@ public static class HttpHeaderExtension
         return correlationId;
     }
 
+    /// <summary>
+    /// Gets the forwarded host from the <c>X-Forwarded-Host</c> header, falling back to the request's own host when the header is not set.
+    /// </summary>
+    /// <param name="httpRequest">The request to read the host from.</param>
+    /// <returns>The forwarded host value, or the request's host if the header is missing or empty.</returns>
     public static string GetForwardedHost(this HttpRequest httpRequest)
     {
         var host = httpRequest.Headers[ForwardedHost];
@@ -33,6 +46,12 @@ public static class HttpHeaderExtension
         return host!;
     }
 
+    /// <summary>
+    /// Gets the first language listed in the <c>Accept-Language</c> header, falling back to <paramref name="defaultLanguage"/> when the header is missing or empty.
+    /// </summary>
+    /// <param name="headers">The header collection to read from.</param>
+    /// <param name="defaultLanguage">The value to return when the <c>Accept-Language</c> header is not present. Defaults to an empty string.</param>
+    /// <returns>The first language from the <c>Accept-Language</c> header, or <paramref name="defaultLanguage"/> when none is present.</returns>
     public static string GetDefaultAcceptLanguage(
         this IHeaderDictionary headers,
         string defaultLanguage = "")

--- a/src/BlogDoFT.Libs.DapperUtils.Abstractions/Extensions/PaginatedSqlBuilderException.cs
+++ b/src/BlogDoFT.Libs.DapperUtils.Abstractions/Extensions/PaginatedSqlBuilderException.cs
@@ -2,19 +2,35 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace BlogDoFT.Libs.DapperUtils.Abstractions.Extensions;
 
+/// <summary>
+/// Represents errors raised while building a paginated SQL query.
+/// </summary>
 [ExcludeFromCodeCoverage]
 [Serializable]
 public class PaginatedSqlBuilderException : Exception
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PaginatedSqlBuilderException"/> class.
+    /// </summary>
     public PaginatedSqlBuilderException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PaginatedSqlBuilderException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
     public PaginatedSqlBuilderException(string message)
         : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PaginatedSqlBuilderException"/> class with a specified error message
+    /// and a reference to the inner exception that caused this exception.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="inner">The exception that is the cause of the current exception.</param>
     public PaginatedSqlBuilderException(string message, Exception inner)
         : base(message, inner)
     {

--- a/src/BlogDoFT.Libs.DapperUtils.Abstractions/Extensions/SqlExtensions.cs
+++ b/src/BlogDoFT.Libs.DapperUtils.Abstractions/Extensions/SqlExtensions.cs
@@ -3,8 +3,17 @@ using System.Text;
 
 namespace BlogDoFT.Libs.DapperUtils.Abstractions.Extensions;
 
+/// <summary>
+/// Provides extension methods to help build SQL-friendly string values.
+/// </summary>
 public static class SqlExtensions
 {
+    /// <summary>
+    /// Converts the wildcard character '*' into the SQL wildcard '%'.
+    /// </summary>
+    /// <param name="value">The string to be converted.</param>
+    /// <param name="toUpperCase">When <see langword="true"/>, the returned value is converted to upper case. Defaults to <see langword="true"/>.</param>
+    /// <returns>The value with '*' replaced by '%', optionally upper-cased.</returns>
     public static string AsSqlWildCard(this string value, bool toUpperCase = true)
     {
         var sqlField = value.Replace('*', '%');
@@ -16,6 +25,12 @@ public static class SqlExtensions
         return sqlField;
     }
 
+    /// <summary>
+    /// Normalizes a string for case- and accent-insensitive search by removing diacritics
+    /// (including cedillas) and converting the result to upper case.
+    /// </summary>
+    /// <param name="value">The string to be normalized. Can be <see langword="null"/>.</param>
+    /// <returns>The normalized, upper-case, accent-free string, or <see cref="string.Empty"/> when <paramref name="value"/> is <see langword="null"/> or whitespace.</returns>
     public static string ToSearchable(this string? value)
     {
         if (string.IsNullOrWhiteSpace(value))

--- a/src/BlogDoFT.Libs.DapperUtils.Abstractions/IConnectionFactory.cs
+++ b/src/BlogDoFT.Libs.DapperUtils.Abstractions/IConnectionFactory.cs
@@ -2,7 +2,14 @@ using System.Data;
 
 namespace BlogDoFT.Libs.DapperUtils.Abstractions;
 
+/// <summary>
+/// Creates database connections.
+/// </summary>
 public interface IConnectionFactory
 {
+    /// <summary>
+    /// Creates a new database connection.
+    /// </summary>
+    /// <returns>A new <see cref="IDbConnection"/> instance.</returns>
     IDbConnection GetNewConnection();
 }

--- a/src/BlogDoFT.Libs.DapperUtils.Abstractions/IDatabaseFacade.cs
+++ b/src/BlogDoFT.Libs.DapperUtils.Abstractions/IDatabaseFacade.cs
@@ -2,20 +2,62 @@ using System.Data;
 
 namespace BlogDoFT.Libs.DapperUtils.Abstractions;
 
+/// <summary>
+/// Abstracts Dapper database operations to enable testing and decouple consumers from a concrete connection.
+/// </summary>
 public interface IDatabaseFacade : IDisposable
 {
+    /// <summary>
+    /// Gets the underlying database connection.
+    /// </summary>
+    /// <returns>The <see cref="IDbConnection"/> used by this facade.</returns>
     IDbConnection GetDbConnection();
 
+    /// <summary>
+    /// Executes a query and returns the resulting rows mapped to <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type to map each result row to.</typeparam>
+    /// <param name="sql">The SQL statement to execute.</param>
+    /// <param name="param">The parameters to pass to the query, if any.</param>
+    /// <returns>The sequence of mapped results.</returns>
     Task<IEnumerable<T>> QueryAsync<T>(
         string sql,
         object? param = null);
 
+    /// <summary>
+    /// Executes a query and returns the first result, or the default value of <typeparamref name="T"/> if no result is found.
+    /// </summary>
+    /// <typeparam name="T">The type to map the result row to.</typeparam>
+    /// <param name="sql">The SQL statement to execute.</param>
+    /// <param name="param">The parameters to pass to the query, if any.</param>
+    /// <returns>The first mapped result, or <see langword="default"/> if none was found.</returns>
     Task<T?> QuerySingleOrDefaultAsync<T>(string sql, object? param = null);
 
+    /// <summary>
+    /// Executes a non-query SQL command.
+    /// </summary>
+    /// <param name="sql">The SQL statement to execute.</param>
+    /// <param name="param">The parameters to pass to the command, if any.</param>
+    /// <param name="transaction">The transaction to execute the command within, if any.</param>
+    /// <returns>The number of rows affected.</returns>
     Task<int> ExecuteAsync(string sql, object? param = null, IDbTransaction? transaction = null);
 
+    /// <summary>
+    /// Executes a SQL statement and returns the first column of the first row of the result.
+    /// </summary>
+    /// <typeparam name="TReturn">The type to convert the scalar result to.</typeparam>
+    /// <param name="sql">The SQL statement to execute.</param>
+    /// <param name="param">The parameters to pass to the command, if any.</param>
+    /// <param name="transaction">The transaction to execute the command within, if any.</param>
+    /// <returns>The scalar result, or the default value of <typeparamref name="TReturn"/> if the result is <see langword="null"/>.</returns>
     Task<TReturn?> ExecuteScalarAsync<TReturn>(string sql, object? param = null, IDbTransaction? transaction = null);
 
+    /// <summary>
+    /// Executes a SQL statement that returns multiple result sets.
+    /// </summary>
+    /// <param name="sql">The SQL statement to execute.</param>
+    /// <param name="param">The parameters to pass to the query.</param>
+    /// <returns>An <see cref="IGridReaderFacade"/> used to read the multiple result sets.</returns>
     Task<IGridReaderFacade> QueryMultipleAsync(
         string sql,
         object? param);

--- a/src/BlogDoFT.Libs.DapperUtils.Abstractions/IGridReaderFacade.cs
+++ b/src/BlogDoFT.Libs.DapperUtils.Abstractions/IGridReaderFacade.cs
@@ -1,10 +1,30 @@
 namespace BlogDoFT.Libs.DapperUtils.Abstractions;
 
+/// <summary>
+/// Abstracts Dapper's grid reader to allow reading multiple result sets produced by a single query.
+/// </summary>
 public interface IGridReaderFacade : IDisposable
 {
+    /// <summary>
+    /// Reads the next result set and returns its first row, or the default value of <typeparamref name="T"/> if it is empty.
+    /// </summary>
+    /// <typeparam name="T">The type to map the result row to.</typeparam>
+    /// <returns>The first mapped result, or <see langword="default"/> if none was found.</returns>
     Task<T?> ReadFirstOrDefaultAsync<T>();
 
+    /// <summary>
+    /// Reads the next result set synchronously.
+    /// </summary>
+    /// <typeparam name="T">The type to map each result row to.</typeparam>
+    /// <param name="buffered">When <see langword="true"/>, the entire result set is read into memory before returning. Defaults to <see langword="true"/>.</param>
+    /// <returns>The sequence of mapped results.</returns>
     IEnumerable<T> Read<T>(bool buffered = true);
 
+    /// <summary>
+    /// Reads the next result set asynchronously.
+    /// </summary>
+    /// <typeparam name="T">The type to map each result row to.</typeparam>
+    /// <param name="buffered">When <see langword="true"/>, the entire result set is read into memory before returning. Defaults to <see langword="true"/>.</param>
+    /// <returns>The sequence of mapped results.</returns>
     Task<IEnumerable<T>> ReadAsync<T>(bool buffered = true);
 }

--- a/src/BlogDoFT.Libs.DapperUtils.Abstractions/Impl/GridReaderFacade.cs
+++ b/src/BlogDoFT.Libs.DapperUtils.Abstractions/Impl/GridReaderFacade.cs
@@ -3,30 +3,45 @@ using static Dapper.SqlMapper;
 
 namespace BlogDoFT.Libs.DapperUtils.Abstractions.Impl;
 
+/// <summary>
+/// Default <see cref="IGridReaderFacade"/> implementation that wraps a Dapper <see cref="GridReader"/>.
+/// </summary>
 [ExcludeFromCodeCoverage]
 public class GridReaderFacade : IGridReaderFacade
 {
     private readonly GridReader _gridReader;
     private bool _disposed;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GridReaderFacade"/> class.
+    /// </summary>
+    /// <param name="gridReader">The Dapper grid reader to wrap.</param>
     public GridReaderFacade(GridReader gridReader) =>
         _gridReader = gridReader;
 
+    /// <inheritdoc/>
     public void Dispose()
     {
         Dispose(true);
         GC.SuppressFinalize(this);
     }
 
+    /// <inheritdoc/>
     public IEnumerable<T> Read<T>(bool buffered = true) =>
         _gridReader.Read<T>(buffered);
 
+    /// <inheritdoc/>
     public Task<IEnumerable<T>> ReadAsync<T>(bool buffered = true)
         => _gridReader.ReadAsync<T>(buffered);
 
+    /// <inheritdoc/>
     public Task<T?> ReadFirstOrDefaultAsync<T>() =>
         _gridReader.ReadFirstOrDefaultAsync<T>();
 
+    /// <summary>
+    /// Releases the resources used by the underlying grid reader.
+    /// </summary>
+    /// <param name="disposing">When <see langword="true"/>, releases both managed and unmanaged resources; otherwise releases only unmanaged resources.</param>
     protected virtual void Dispose(bool disposing)
     {
         if (_disposed)

--- a/src/BlogDoFT.Libs.DapperUtils.Abstractions/PageFilter.cs
+++ b/src/BlogDoFT.Libs.DapperUtils.Abstractions/PageFilter.cs
@@ -1,10 +1,22 @@
 namespace BlogDoFT.Libs.DapperUtils.Abstractions;
 
+/// <summary>
+/// Represents pagination and ordering criteria for a query.
+/// </summary>
 public readonly struct PageFilter
 {
+    /// <summary>
+    /// Gets the page number to retrieve.
+    /// </summary>
     public int Page { get; init; }
 
+    /// <summary>
+    /// Gets the number of items per page.
+    /// </summary>
     public int Size { get; init; }
 
+    /// <summary>
+    /// Gets the ordering clause to apply, if any.
+    /// </summary>
     public string? Order { get; init; }
 }

--- a/src/BlogDoFT.Libs.DapperUtils.Abstractions/TypeHandlers/SqlDateOnlyTypeHandler.cs
+++ b/src/BlogDoFT.Libs.DapperUtils.Abstractions/TypeHandlers/SqlDateOnlyTypeHandler.cs
@@ -4,11 +4,16 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace BlogDoFT.Libs.DapperUtils.Abstractions.TypeHandlers;
 
+/// <summary>
+/// Dapper type handler that maps <see cref="DateOnly"/> values to and from <see cref="DateTime"/> database columns.
+/// </summary>
 [ExcludeFromCodeCoverage]
 public class SqlDateOnlyTypeHandler : SqlMapper.TypeHandler<DateOnly>
 {
+    /// <inheritdoc/>
     public override void SetValue(IDbDataParameter parameter, DateOnly date)
         => parameter.Value = date.ToDateTime(new TimeOnly(0, 0));
 
+    /// <inheritdoc/>
     public override DateOnly Parse(object value) => DateOnly.FromDateTime((DateTime)value);
 }

--- a/src/BlogDoFT.Libs.DapperUtils.Abstractions/TypeHandlers/SqlTimeOnlyTypeHandler.cs
+++ b/src/BlogDoFT.Libs.DapperUtils.Abstractions/TypeHandlers/SqlTimeOnlyTypeHandler.cs
@@ -4,13 +4,18 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace BlogDoFT.Libs.DapperUtils.Abstractions.TypeHandlers;
 
+/// <summary>
+/// Dapper type handler that maps <see cref="TimeOnly"/> values to and from database columns.
+/// </summary>
 [ExcludeFromCodeCoverage]
 public class SqlTimeOnlyTypeHandler : SqlMapper.TypeHandler<TimeOnly>
 {
+    /// <inheritdoc/>
     public override void SetValue(IDbDataParameter parameter, TimeOnly time)
     {
         parameter.Value = time.ToString();
     }
 
+    /// <inheritdoc/>
     public override TimeOnly Parse(object value) => TimeOnly.FromTimeSpan((TimeSpan)value);
 }

--- a/src/BlogDoFT.Libs.DapperUtils.Postgres/DapperUtilsPostgresExtensions.cs
+++ b/src/BlogDoFT.Libs.DapperUtils.Postgres/DapperUtilsPostgresExtensions.cs
@@ -7,6 +7,11 @@ namespace BlogDoFT.Libs.DapperUtils.Postgres;
 [ExcludeFromCodeCoverage]
 public static class DapperUtilsPostgresExtensions
 {
+    /// <summary>
+    /// Registers the default Postgres-backed <see cref="IConnectionFactory"/> and <see cref="IDatabaseFacade"/> implementations.
+    /// </summary>
+    /// <param name="services">The service collection to register the dependencies into.</param>
+    /// <returns>The same service collection, to allow chaining.</returns>
     public static IServiceCollection AddDapperPostgres(this IServiceCollection services)
     {
         return services
@@ -14,6 +19,13 @@ public static class DapperUtilsPostgresExtensions
             .AddScoped<IDatabaseFacade, PostgresDatabaseFacade>();
     }
 
+    /// <summary>
+    /// Registers the default Postgres-backed <see cref="IDatabaseFacade"/> implementation and replaces the
+    /// registered <see cref="IConnectionFactory"/> with the supplied instance.
+    /// </summary>
+    /// <param name="services">The service collection to register the dependencies into.</param>
+    /// <param name="connectionFactory">The connection factory instance to use instead of the default one.</param>
+    /// <returns>The same service collection, to allow chaining.</returns>
     public static IServiceCollection AddDapperPostgres(
         this IServiceCollection services,
         IConnectionFactory connectionFactory)

--- a/src/BlogDoFT.Libs.DapperUtils.Postgres/OrderByResolver.cs
+++ b/src/BlogDoFT.Libs.DapperUtils.Postgres/OrderByResolver.cs
@@ -4,6 +4,10 @@ using System.Text;
 
 namespace BlogDoFT.Libs.DapperUtils.Postgres;
 
+/// <summary>
+/// Translates user-supplied "order by" field names into their corresponding SQL <c>ORDER BY</c> clause,
+/// using a mapping between the two.
+/// </summary>
 public class OrderByResolver
 {
     private const string Ascending = "ASC";
@@ -11,14 +15,35 @@ public class OrderByResolver
 
     private readonly ImmutableDictionary<string, string> _fromTo;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OrderByResolver"/> class.
+    /// </summary>
+    /// <param name="fromTo">A mapping from user-facing field names to their corresponding SQL field names.</param>
     public OrderByResolver(Dictionary<string, string> fromTo)
         : this(fromTo.ToImmutableDictionary())
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OrderByResolver"/> class.
+    /// </summary>
+    /// <param name="fromTo">
+    /// A mapping from user-facing field names to their corresponding SQL field names. When <see langword="null"/>,
+    /// no field is resolved and <see cref="Resolve"/> always returns an empty <see cref="StringBuilder"/>.
+    /// </param>
     public OrderByResolver(ImmutableDictionary<string, string>? fromTo) =>
         _fromTo = fromTo ?? new Dictionary<string, string>().ToImmutableDictionary();
 
+    /// <summary>
+    /// Builds a SQL <c>ORDER BY</c> clause from a comma-separated list of user-facing field names, each optionally
+    /// followed by a space and an <c>ASC</c> or <c>DESC</c> direction (defaulting to <c>ASC</c>). Fields not present
+    /// in the mapping supplied to the constructor are ignored.
+    /// </summary>
+    /// <param name="userOrderBy">The comma-separated, user-facing "order by" expression, e.g. <c>"name desc, id"</c>.</param>
+    /// <returns>
+    /// A <see cref="StringBuilder"/> containing the resolved <c>ORDER BY</c> clause, or an empty one when
+    /// <paramref name="userOrderBy"/> is <see langword="null"/>, blank, or maps to no known field.
+    /// </returns>
     public StringBuilder Resolve(string? userOrderBy)
     {
         var orderBy = new StringBuilder();

--- a/src/BlogDoFT.Libs.DapperUtils.Postgres/PageCountStmt.cs
+++ b/src/BlogDoFT.Libs.DapperUtils.Postgres/PageCountStmt.cs
@@ -2,10 +2,18 @@ using System.Text;
 
 namespace BlogDoFT.Libs.DapperUtils.Postgres;
 
+/// <summary>
+/// Builds a SQL statement that counts the total rows produced by another query.
+/// </summary>
 public static class PageCountStmt
 {
     private const string SqlCount = "select count(1) from ({0}) as counter_result";
 
+    /// <summary>
+    /// Wraps the given SQL query in a <c>SELECT COUNT(1)</c> statement, to obtain the total number of rows it produces.
+    /// </summary>
+    /// <param name="sql">The SQL query to be counted.</param>
+    /// <returns>A new <see cref="StringBuilder"/> containing the count statement.</returns>
     public static StringBuilder BuildCountSql(StringBuilder sql) =>
         new StringBuilder()
             .AppendFormat(SqlCount, sql);

--- a/src/BlogDoFT.Libs.DapperUtils.Postgres/PaginatedSqlBuilder.cs
+++ b/src/BlogDoFT.Libs.DapperUtils.Postgres/PaginatedSqlBuilder.cs
@@ -5,6 +5,10 @@ using System.Text;
 
 namespace BlogDoFT.Libs.DapperUtils.Postgres;
 
+/// <summary>
+/// Fluent builder that assembles a paginated SQL query and its matching row-count query, combining a result
+/// set, a <see cref="WhereBuilder"/>, an <see cref="OrderByResolver"/> mapping, and a <see cref="PageFilter"/>.
+/// </summary>
 public class PaginatedSqlBuilder
 {
     private readonly WhereBuilder _where;
@@ -12,11 +16,26 @@ public class PaginatedSqlBuilder
     private PageFilter _pageFilter;
     private ImmutableDictionary<string, string>? _orderMap;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PaginatedSqlBuilder"/> class.
+    /// </summary>
     public PaginatedSqlBuilder()
     {
         _where = new WhereBuilder();
     }
 
+    /// <summary>
+    /// Builds the paginated query and its corresponding row-count query, from the result set, filters,
+    /// ordering, and pagination configured on this builder.
+    /// </summary>
+    /// <returns>
+    /// A tuple containing the paginated <c>Query</c> (with <c>WHERE</c>, <c>ORDER BY</c>, and <c>LIMIT</c>/<c>OFFSET</c>
+    /// applied) and the <c>QuerySize</c> statement that counts the total rows matching the same filters.
+    /// </returns>
+    /// <exception cref="PaginatedSqlBuilderException">
+    /// Thrown when no result set was configured via <see cref="WithResultSet"/>, or no pagination was
+    /// configured via <see cref="WithPagination"/>.
+    /// </exception>
     public (StringBuilder Query, StringBuilder QuerySize) Build()
     {
         ValidateBuild();
@@ -42,30 +61,63 @@ public class PaginatedSqlBuilder
         return (Query: paginatedQuery, QuerySize: querySize);
     }
 
+    /// <summary>
+    /// Sets the base SQL result set (e.g. a <c>SELECT ... FROM ...</c> statement) that filters, ordering, and
+    /// pagination are applied on top of.
+    /// </summary>
+    /// <param name="resultSet">The base SQL query.</param>
+    /// <returns>The same builder instance, to allow chaining.</returns>
     public PaginatedSqlBuilder WithResultSet(string resultSet)
     {
         _resultSet = resultSet;
         return this;
     }
 
+    /// <summary>
+    /// Adds a single user-facing field to SQL field mapping, used to resolve the <c>ORDER BY</c> clause.
+    /// </summary>
+    /// <param name="key">The user-facing field name.</param>
+    /// <param name="value">The corresponding SQL field name.</param>
+    /// <returns>The same builder instance, to allow chaining.</returns>
     public PaginatedSqlBuilder MappingOrderWith(string key, string value) =>
         MappingOrderWith(new Dictionary<string, string> { { key, value } });
 
+    /// <summary>
+    /// Sets the user-facing field to SQL field mapping, used to resolve the <c>ORDER BY</c> clause.
+    /// </summary>
+    /// <param name="orderMap">The mapping from user-facing field names to their corresponding SQL field names.</param>
+    /// <returns>The same builder instance, to allow chaining.</returns>
     public PaginatedSqlBuilder MappingOrderWith(Dictionary<string, string> orderMap) =>
         MappingOrderWith(orderMap.ToImmutableDictionary());
 
+    /// <summary>
+    /// Sets the user-facing field to SQL field mapping, used to resolve the <c>ORDER BY</c> clause.
+    /// </summary>
+    /// <param name="orderMap">The mapping from user-facing field names to their corresponding SQL field names.</param>
+    /// <returns>The same builder instance, to allow chaining.</returns>
     public PaginatedSqlBuilder MappingOrderWith(ImmutableDictionary<string, string> orderMap)
     {
         _orderMap = orderMap;
         return this;
     }
 
+    /// <summary>
+    /// Sets the page number and page size to apply to the query.
+    /// </summary>
+    /// <param name="pageFilter">The pagination settings.</param>
+    /// <returns>The same builder instance, to allow chaining.</returns>
     public PaginatedSqlBuilder WithPagination(PageFilter pageFilter)
     {
         _pageFilter = pageFilter;
         return this;
     }
 
+    /// <summary>
+    /// Configures the <c>WHERE</c> clause conditions by invoking the given callback against the builder's
+    /// internal <see cref="WhereBuilder"/>.
+    /// </summary>
+    /// <param name="where">A callback that adds conditions to the supplied <see cref="WhereBuilder"/>.</param>
+    /// <returns>The same builder instance, to allow chaining.</returns>
     public PaginatedSqlBuilder WithWhere(Action<WhereBuilder> where)
     {
         where(_where);

--- a/src/BlogDoFT.Libs.DapperUtils.Postgres/SqlPagination.cs
+++ b/src/BlogDoFT.Libs.DapperUtils.Postgres/SqlPagination.cs
@@ -2,6 +2,9 @@ using BlogDoFT.Libs.DapperUtils.Abstractions;
 
 namespace BlogDoFT.Libs.DapperUtils.Postgres;
 
+/// <summary>
+/// Builds SQL <c>LIMIT</c>/<c>OFFSET</c> clauses for paginated queries.
+/// </summary>
 public static class SqlPagination
 {
     internal const int MinPageNumber = 0;
@@ -14,9 +17,26 @@ public static class SqlPagination
     private static readonly string _pageSizeRangeError =
         $"Page size must be between {MinPageSize} and {MaxPageSize}";
 
+    /// <summary>
+    /// Builds a SQL <c>LIMIT</c>/<c>OFFSET</c> clause for the given page number and page size.
+    /// </summary>
+    /// <param name="pageNumber">The zero-based page number to retrieve.</param>
+    /// <param name="pageSize">The number of rows per page.</param>
+    /// <returns>The SQL <c>LIMIT</c>/<c>OFFSET</c> clause.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="pageNumber"/> is negative, or <paramref name="pageSize"/> is outside the allowed range.
+    /// </exception>
     public static string GetPagination(int pageNumber, int pageSize) =>
          From(new PageFilter { Page = pageNumber, Size = pageSize });
 
+    /// <summary>
+    /// Builds a SQL <c>LIMIT</c>/<c>OFFSET</c> clause from the given <see cref="PageFilter"/>.
+    /// </summary>
+    /// <param name="pagination">The page and size to build the clause from.</param>
+    /// <returns>The SQL <c>LIMIT</c>/<c>OFFSET</c> clause.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="pagination"/>'s page is negative, or its size is outside the allowed range.
+    /// </exception>
     public static string From(PageFilter pagination)
     {
         if (pagination.Page < MinPageNumber)

--- a/src/BlogDoFT.Libs.DapperUtils.Postgres/WhereBuilder.cs
+++ b/src/BlogDoFT.Libs.DapperUtils.Postgres/WhereBuilder.cs
@@ -2,6 +2,10 @@ using System.Text;
 
 namespace BlogDoFT.Libs.DapperUtils.Postgres;
 
+/// <summary>
+/// Fluent builder that assembles a SQL <c>WHERE</c> clause from conditions, skipping any whose associated
+/// parameter value is <see langword="null"/>.
+/// </summary>
 public class WhereBuilder
 {
     private const string OpenAnd = " and (";
@@ -11,9 +15,19 @@ public class WhereBuilder
     private const string OpenOr = "  or (";
     private readonly StringBuilder _where;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WhereBuilder"/> class.
+    /// </summary>
     public WhereBuilder() =>
         _where = new StringBuilder();
 
+    /// <summary>
+    /// Builds the final SQL <c>WHERE</c> clause from the conditions added so far.
+    /// </summary>
+    /// <returns>
+    /// A <see cref="StringBuilder"/> starting with <c>"where "</c> followed by the accumulated conditions,
+    /// or an empty <see cref="StringBuilder"/> when no condition was added.
+    /// </returns>
     public StringBuilder Build()
     {
         if (_where.Length == 0)
@@ -25,6 +39,12 @@ public class WhereBuilder
             .Append(_where.ToString()[4..]);
     }
 
+    /// <summary>
+    /// Adds a condition combined with <c>AND</c> to the clause, but only when <paramref name="paramValue"/> is not <see langword="null"/>.
+    /// </summary>
+    /// <param name="paramValue">The parameter value associated with the condition. When <see langword="null"/>, the condition is skipped.</param>
+    /// <param name="condition">The SQL condition text to add.</param>
+    /// <returns>The same builder instance, to allow chaining.</returns>
     public WhereBuilder AndWith(object? paramValue, string condition)
     {
         if (paramValue is not null)
@@ -38,6 +58,12 @@ public class WhereBuilder
         return this;
     }
 
+    /// <summary>
+    /// Adds a condition combined with <c>OR</c> to the clause, but only when <paramref name="paramValue"/> is not <see langword="null"/>.
+    /// </summary>
+    /// <param name="paramValue">The parameter value associated with the condition. When <see langword="null"/>, the condition is skipped.</param>
+    /// <param name="condition">The SQL condition text to add.</param>
+    /// <returns>The same builder instance, to allow chaining.</returns>
     public WhereBuilder OrWith(object? paramValue, string condition)
     {
         if (paramValue is not null)

--- a/src/BlogDoFT.Libs.DomainNotifications.Extensions/DomainNotificationExtensions.cs
+++ b/src/BlogDoFT.Libs.DomainNotifications.Extensions/DomainNotificationExtensions.cs
@@ -2,8 +2,18 @@ using BlogDoFT.Libs.ResultPattern;
 
 namespace BlogDoFT.Libs.DomainNotifications.Extensions;
 
+/// <summary>
+/// Provides extension methods to add domain notifications from <see cref="Result"/>, <see cref="Failure"/>,
+/// and <see cref="Exception"/> instances.
+/// </summary>
 public static class DomainNotificationExtensions
 {
+    /// <summary>
+    /// Adds a domain notification built from the failure of the specified <paramref name="result"/>.
+    /// No notification is added when the result represents success.
+    /// </summary>
+    /// <param name="domainNotifications">The notification collection to add to.</param>
+    /// <param name="result">The result to inspect.</param>
     public static void Add(this IDomainNotifications domainNotifications, Result result)
     {
         if (result.IsSuccess)
@@ -14,6 +24,12 @@ public static class DomainNotificationExtensions
         domainNotifications.Add(message: result.Failure.Message, code: result.Failure.Code);
     }
 
+    /// <summary>
+    /// Adds a domain notification built from the specified <paramref name="failure"/>.
+    /// No notification is added when <paramref name="failure"/> is <see cref="Failure.None"/>.
+    /// </summary>
+    /// <param name="domainNotifications">The notification collection to add to.</param>
+    /// <param name="failure">The failure to convert into a notification.</param>
     public static void Add(this IDomainNotifications domainNotifications, Failure failure)
     {
         if (failure == Failure.None)
@@ -24,6 +40,13 @@ public static class DomainNotificationExtensions
         domainNotifications.Add(message: failure.Message, code: failure.Code);
     }
 
+    /// <summary>
+    /// Adds a domain notification built from the failure of the specified <paramref name="result"/>.
+    /// No notification is added when the result represents success.
+    /// </summary>
+    /// <typeparam name="T">The type of the value produced by a successful result.</typeparam>
+    /// <param name="domainNotifications">The notification collection to add to.</param>
+    /// <param name="result">The result to inspect.</param>
     public static void Add<T>(this IDomainNotifications domainNotifications, Result<T> result)
     {
         if (result.IsSuccess)
@@ -34,6 +57,12 @@ public static class DomainNotificationExtensions
         domainNotifications.Add(result.Failure);
     }
 
+    /// <summary>
+    /// Adds a domain notification built from the message of the specified <paramref name="exception"/>.
+    /// </summary>
+    /// <param name="domainNotifications">The notification collection to add to.</param>
+    /// <param name="exception">The exception whose message becomes the notification message.</param>
+    /// <param name="code">An optional code to associate with the notification.</param>
     public static void Add(
         this IDomainNotifications domainNotifications,
         Exception exception,

--- a/src/BlogDoFT.Libs.DomainNotifications/DomainNotification.cs
+++ b/src/BlogDoFT.Libs.DomainNotifications/DomainNotification.cs
@@ -1,14 +1,28 @@
 namespace BlogDoFT.Libs.DomainNotifications;
 
+/// <summary>
+/// Represents a single domain notification, carrying a message and an optional identifying code.
+/// </summary>
 public record DomainNotification
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DomainNotification"/> record.
+    /// </summary>
+    /// <param name="message">The notification message.</param>
+    /// <param name="code">An optional code identifying the notification.</param>
     public DomainNotification(string message, string? code = null)
     {
         Message = message;
         Code = code;
     }
 
+    /// <summary>
+    /// Gets the code identifying the notification, if any.
+    /// </summary>
     public string? Code { get; init; }
 
+    /// <summary>
+    /// Gets the notification message.
+    /// </summary>
     public string Message { get; }
 }

--- a/src/BlogDoFT.Libs.DomainNotifications/DomainNotificationExtension.cs
+++ b/src/BlogDoFT.Libs.DomainNotifications/DomainNotificationExtension.cs
@@ -2,8 +2,16 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace BlogDoFT.Libs.DomainNotifications;
 
+/// <summary>
+/// Provides extension methods to register domain notification services.
+/// </summary>
 public static class DomainNotificationExtension
 {
+    /// <summary>
+    /// Registers <see cref="IDomainNotifications"/> as a scoped service backed by an internal notification bag.
+    /// </summary>
+    /// <param name="services">The service collection to add the registration to.</param>
+    /// <returns>The same <see cref="IServiceCollection"/> instance, so calls can be chained.</returns>
     public static IServiceCollection AddDomainNotification(this IServiceCollection services)
     {
         return services.AddScoped<IDomainNotifications, DomainNotificationBag>();

--- a/src/BlogDoFT.Libs.DomainNotifications/IDomainNotifications.cs
+++ b/src/BlogDoFT.Libs.DomainNotifications/IDomainNotifications.cs
@@ -27,17 +27,19 @@ public interface IDomainNotifications
     /// <summary>
     /// Get a new IEnumerable instance from Domain Notifications.
     /// </summary>
-    /// <returns></returns>
+    /// <returns>An enumerable collection of the stored domain notifications.</returns>
     IEnumerable<DomainNotification> ToEnumerable();
 
     /// <summary>
     /// Return a DomainNotification at index
     /// </summary>
+    /// <param name="index">The zero-based index of the notification to retrieve.</param>
+    /// <returns>The domain notification at the specified index.</returns>
     DomainNotification this[int index] { get; }
 
     /// <summary>
     /// Returns how many DomainNotifications has stored.
     /// </summary>
-    /// <returns></returns>
+    /// <returns>The number of stored domain notifications.</returns>
     int Count();
 }

--- a/src/BlogDoFT.Libs.EntityFramework.CodeGenerator/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/BlogDoFT.Libs.EntityFramework.CodeGenerator/Diagnostics/DiagnosticDescriptors.cs
@@ -3,6 +3,9 @@ using System.Linq;
 
 namespace BlogDoFT.Libs.EntityFramework.CodeGenerator.Diagnostics;
 
+/// <summary>
+/// Provides the <see cref="DiagnosticDescriptor"/> instances reported by <see cref="Generators.PredicateGenerator"/>.
+/// </summary>
 public static class DiagnosticDescriptors
 {
     private const string DefaultCategoryUsage = "PredicateGenerator.Usage";
@@ -10,6 +13,9 @@ public static class DiagnosticDescriptors
     private const string DefaultCategoryGeneration = "PredicateGenerator.Generation";
     private const string HelpBase = "https://example.com/docs/predicate-generator/"; // opcional: troque para sua URL
 
+    /// <summary>
+    /// Reported when a filter DTO annotated with <c>[GeneratePredicate&lt;TEntity&gt;]</c> is not declared as <c>partial</c>.
+    /// </summary>
     public static readonly DiagnosticDescriptor FilterDtoMustBePartial = new(
         id: "PG001",
         title: "Filter DTO must be partial",
@@ -20,6 +26,9 @@ public static class DiagnosticDescriptors
         description: "The source generator emits members (e.g., ToPredicate, HasFilter) into a partial type. Non-partial types cannot be augmented.",
         helpLinkUri: HelpLink("PG001"));
 
+    /// <summary>
+    /// Reported when a property's <c>TargetProperty</c> path cannot be resolved on the target entity type.
+    /// </summary>
     public static readonly DiagnosticDescriptor TargetPropertyPathInvalid = new(
         id: "PG002",
         title: "Invalid TargetProperty path",
@@ -30,6 +39,9 @@ public static class DiagnosticDescriptors
         description: "The TargetProperty must reference a valid member path on the target entity (supports dotted paths).",
         helpLinkUri: HelpLink("PG002"));
 
+    /// <summary>
+    /// Reported when a DTO property is annotated with a filter attribute the generator does not recognize.
+    /// </summary>
     public static readonly DiagnosticDescriptor UnsupportedFilterAttribute = new(
         id: "PG003",
         title: "Unsupported filter attribute",
@@ -40,6 +52,9 @@ public static class DiagnosticDescriptors
         description: "Only StringFilterAttribute, NumericFilterAttribute, TemporalFilterAttribute, and BooleanFilterAttribute are recognized.",
         helpLinkUri: HelpLink("PG003"));
 
+    /// <summary>
+    /// Reported when a filter DTO has no properties annotated with a supported filter attribute.
+    /// </summary>
     public static readonly DiagnosticDescriptor NoFilterablePropertiesFound = new(
         id: "PG004",
         title: "No filterable properties found",
@@ -50,6 +65,9 @@ public static class DiagnosticDescriptors
         description: "The generator emits a trivial predicate when no annotated properties are present.",
         helpLinkUri: HelpLink("PG004"));
 
+    /// <summary>
+    /// Reported when a declared <c>ComparisonOperator</c> does not apply to the type of the target member.
+    /// </summary>
     public static readonly DiagnosticDescriptor ComparisonOperatorNotApplicable = new(
         id: "PG005",
         title: "Comparison operator not applicable",
@@ -60,6 +78,9 @@ public static class DiagnosticDescriptors
         description: "Ensure the operator matches the target member type (numeric or temporal).",
         helpLinkUri: HelpLink("PG005"));
 
+    /// <summary>
+    /// Reported when the entity type argument of <c>[GeneratePredicate&lt;TEntity&gt;]</c> cannot be resolved.
+    /// </summary>
     public static readonly DiagnosticDescriptor EntityTypeNotResolved = new(
         id: "PG010",
         title: "Cannot resolve entity type",
@@ -70,6 +91,9 @@ public static class DiagnosticDescriptors
         description: "The generic attribute must provide a valid type argument corresponding to the target entity.",
         helpLinkUri: HelpLink("PG010"));
 
+    /// <summary>
+    /// Reported when generated members are emitted with <c>internal</c> visibility because the DTO or entity type is not public.
+    /// </summary>
     public static readonly DiagnosticDescriptor GeneratedMembersSetToInternal = new(
         id: "PG101",
         title: "Generated members emitted as 'internal'",
@@ -80,6 +104,9 @@ public static class DiagnosticDescriptors
         description: "ToPredicate and HasFilter visibility matches the least accessible type in their signatures.",
         helpLinkUri: HelpLink("PG101"));
 
+    /// <summary>
+    /// Informational diagnostic confirming that predicate members were successfully generated for a DTO.
+    /// </summary>
     public static readonly DiagnosticDescriptor GenerationSucceeded = new(
         id: "PG200",
         title: "Predicate generation succeeded",
@@ -90,6 +117,9 @@ public static class DiagnosticDescriptors
         description: "Informational banner to confirm successful code emission.",
         helpLinkUri: HelpLink("PG200"));
 
+    /// <summary>
+    /// Reported when an unhandled exception occurs while generating code for a DTO.
+    /// </summary>
     public static readonly DiagnosticDescriptor UnexpectedGenerationFailure = new(
         id: "PG900",
         title: "Unexpected error during code generation",
@@ -102,6 +132,14 @@ public static class DiagnosticDescriptors
 
     private static string? HelpLink(string code) => HelpBase is { Length: > 0 } ? HelpBase + code.ToLowerInvariant() : null;
 
+    /// <summary>
+    /// Creates a <see cref="Diagnostic"/> for the given <paramref name="descriptor"/>, using the first location
+    /// of <paramref name="symbol"/> (or <see cref="Location.None"/> when the symbol is <see langword="null"/> or has no locations).
+    /// </summary>
+    /// <param name="descriptor">The diagnostic descriptor to instantiate.</param>
+    /// <param name="symbol">The symbol whose first declaration location is used to report the diagnostic.</param>
+    /// <param name="messageArgs">Arguments substituted into the descriptor's message format.</param>
+    /// <returns>The created <see cref="Diagnostic"/>.</returns>
     public static Diagnostic Create(DiagnosticDescriptor descriptor, ISymbol? symbol, params object?[] messageArgs)
     {
         var location = symbol?.Locations.FirstOrDefault() ?? Location.None;

--- a/src/BlogDoFT.Libs.EntityFramework.CodeGenerator/Generators/PredicateGenerator.cs
+++ b/src/BlogDoFT.Libs.EntityFramework.CodeGenerator/Generators/PredicateGenerator.cs
@@ -10,9 +10,16 @@ using System.Text;
 
 namespace BlogDoFT.Libs.EntityFramework.CodeGenerator.Generators
 {
+    /// <summary>
+    /// Incremental source generator that emits <c>ToPredicate()</c> and <c>HasFilter()</c> members for
+    /// partial DTOs decorated with <see cref="GeneratePredicateAttribute{TEntity}"/>, based on the
+    /// <see cref="StringFilterAttribute"/>, <see cref="NumericFilterAttribute"/>, <see cref="TemporalFilterAttribute"/>,
+    /// and <see cref="BooleanFilterAttribute"/> annotations declared on their properties.
+    /// </summary>
     [Generator(LanguageNames.CSharp)]
     public sealed class PredicateGenerator : IIncrementalGenerator
     {
+        /// <inheritdoc/>
         public void Initialize(IncrementalGeneratorInitializationContext context)
         {
             var candidates = context.SyntaxProvider

--- a/src/BlogDoFT.Libs.Extensions/EnumExtensions.cs
+++ b/src/BlogDoFT.Libs.Extensions/EnumExtensions.cs
@@ -1,10 +1,25 @@
 namespace BlogDoFT.Libs.Extensions;
 
+/// <summary>
+/// Provides extension methods for converting between enum values, integers, and strings.
+/// </summary>
 public static class EnumExtensions
 {
+    /// <summary>
+    /// Converts an enum value to its underlying integer representation.
+    /// </summary>
+    /// <param name="value">The enum value to convert.</param>
+    /// <returns>The integer value backing <paramref name="value"/>.</returns>
     public static int AsInteger(this Enum value) =>
         Convert.ToInt32(value);
 
+    /// <summary>
+    /// Parses a string into the specified enum type.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type to parse into.</typeparam>
+    /// <param name="enumValue">The string representation of the enum value.</param>
+    /// <returns>The parsed <typeparamref name="TEnum"/> value.</returns>
+    /// <exception cref="InvalidCastException">Thrown when <paramref name="enumValue"/> is not a valid value for <typeparamref name="TEnum"/>.</exception>
     public static TEnum ToEnum<TEnum>(this string enumValue)
         where TEnum : struct
     {

--- a/src/BlogDoFT.Libs.ResultPattern/Failure.cs
+++ b/src/BlogDoFT.Libs.ResultPattern/Failure.cs
@@ -16,8 +16,22 @@ public record class Failure(string Code, string Message)
     private static readonly Lazy<Failure> _dataNotFound = new(() => new("common-404", "Resource not found."));
     private static readonly Lazy<Failure> _validationError = new(() => new("common-400", "Validation error occurred."));
 
+    /// <summary>
+    /// Gets a <see cref="Failure"/> instance that represents the absence of a failure,
+    /// used internally to signal a successful <see cref="Result"/>.
+    /// </summary>
     public static Failure None => _none.Value;
+
+    /// <summary>
+    /// Gets a reusable <see cref="Failure"/> with code <c>common-404</c>, indicating that
+    /// a requested resource could not be found.
+    /// </summary>
     public static Failure DataNotFound => _dataNotFound.Value;
+
+    /// <summary>
+    /// Gets a reusable <see cref="Failure"/> with code <c>common-400</c>, indicating that
+    /// input validation failed.
+    /// </summary>
     public static Failure ValidationError => _validationError.Value;
 }
 #pragma warning restore SA1313 // Parameter names should begin with lower-case letter

--- a/src/BlogDoFT.Libs.ResultPattern/MapExtension.cs
+++ b/src/BlogDoFT.Libs.ResultPattern/MapExtension.cs
@@ -1,5 +1,9 @@
 namespace BlogDoFT.Libs.ResultPattern;
 
+/// <summary>
+/// Provides extension methods to transform a <see cref="Result{TValue}"/> into a plain
+/// value by mapping both its success and failure states.
+/// </summary>
 public static class MapExtension
 {
     /// <summary>

--- a/src/BlogDoFT.Libs.ResultPattern/Result.cs
+++ b/src/BlogDoFT.Libs.ResultPattern/Result.cs
@@ -1,7 +1,17 @@
 namespace BlogDoFT.Libs.ResultPattern;
 
+/// <summary>
+/// Represents the outcome of an operation that does not produce a value, indicating
+/// either success or failure.
+/// </summary>
 public class Result
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Result"/> class.
+    /// </summary>
+    /// <param name="failure">
+    /// The failure associated with this result, or <see cref="Failure.None"/> to represent success.
+    /// </param>
     protected Result(Failure failure)
     {
         Failure = failure;
@@ -22,13 +32,32 @@ public class Result
     /// </summary>
     public Failure Failure { get; }
 
+    /// <summary>
+    /// Implicitly converts a <see cref="Failure"/> into a failed <see cref="Result"/>.
+    /// </summary>
+    /// <param name="failure">The failure to wrap.</param>
+    /// <returns>A <see cref="Result"/> representing the given failure.</returns>
     public static implicit operator Result(Failure failure) => new Result(failure);
 
+    /// <summary>
+    /// Creates a <see cref="Result"/> representing a successful operation.
+    /// </summary>
+    /// <returns>A <see cref="Result"/> whose <see cref="IsSuccess"/> is <see langword="true"/>.</returns>
     public static Result AsSuccess() => new(Failure.None);
 
+    /// <summary>
+    /// Creates a <see cref="Result"/> representing a failed operation.
+    /// </summary>
+    /// <param name="failure">The failure describing why the operation failed.</param>
+    /// <returns>A <see cref="Result"/> whose <see cref="IsFailure"/> is <see langword="true"/>.</returns>
     public static Result AsFailure(Failure failure) => new(failure);
 }
 
+/// <summary>
+/// Represents the outcome of an operation that produces a value of type
+/// <typeparamref name="TValue"/> on success, or a <see cref="Failure"/> otherwise.
+/// </summary>
+/// <typeparam name="TValue">The type of the value produced when the operation succeeds.</typeparam>
 public sealed class Result<TValue> : Result
 {
     private readonly TValue? _value;
@@ -51,6 +80,7 @@ public sealed class Result<TValue> : Result
     /// <remarks>
     /// In case of failure, a exception will be raised.
     /// </remarks>
+    /// <exception cref="ResultException">Thrown when the result represents a failure.</exception>
     public TValue Value
     {
         get
@@ -66,11 +96,32 @@ public sealed class Result<TValue> : Result
         }
     }
 
+    /// <summary>
+    /// Implicitly converts a value of type <typeparamref name="TValue"/> into a successful
+    /// <see cref="Result{TValue}"/>.
+    /// </summary>
+    /// <param name="value">The success value to wrap.</param>
+    /// <returns>A <see cref="Result{TValue}"/> representing success with the given value.</returns>
     public static implicit operator Result<TValue>(TValue value) => FromSuccess(value);
 
+    /// <summary>
+    /// Implicitly converts a <see cref="Failure"/> into a failed <see cref="Result{TValue}"/>.
+    /// </summary>
+    /// <param name="failure">The failure to wrap.</param>
+    /// <returns>A <see cref="Result{TValue}"/> representing the given failure.</returns>
     public static implicit operator Result<TValue>(Failure failure) => FromFailure(failure);
 
+    /// <summary>
+    /// Creates a <see cref="Result{TValue}"/> representing a successful operation.
+    /// </summary>
+    /// <param name="value">The value produced by the successful operation.</param>
+    /// <returns>A <see cref="Result{TValue}"/> whose <see cref="Result.IsSuccess"/> is <see langword="true"/>.</returns>
     public static Result<TValue> FromSuccess(TValue value) => new(value);
 
+    /// <summary>
+    /// Creates a <see cref="Result{TValue}"/> representing a failed operation.
+    /// </summary>
+    /// <param name="failure">The failure describing why the operation failed.</param>
+    /// <returns>A <see cref="Result{TValue}"/> whose <see cref="Result.IsFailure"/> is <see langword="true"/>.</returns>
     public static Result<TValue> FromFailure(Failure failure) => new(failure);
 }

--- a/src/BlogDoFT.Libs.ResultPattern/ResultException.cs
+++ b/src/BlogDoFT.Libs.ResultPattern/ResultException.cs
@@ -1,17 +1,36 @@
 namespace BlogDoFT.Libs.ResultPattern;
 
+/// <summary>
+/// Exception thrown when a <see cref="Result{TValue}"/> is used in a way that is not
+/// consistent with its success or failure state, such as reading <see cref="Result{TValue}.Value"/>
+/// on a failed result.
+/// </summary>
 public class ResultException : Exception
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResultException"/> class with a
+    /// specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
     protected ResultException(string message)
         : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResultException"/> class.
+    /// </summary>
     protected ResultException()
         : base()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResultException"/> class with a
+    /// specified error message and a reference to the inner exception that caused it.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
     protected ResultException(string? message, Exception? innerException)
         : base(message, innerException)
     {

--- a/src/BlogDoFT.Libs.ResultPattern/ResultExtension.cs
+++ b/src/BlogDoFT.Libs.ResultPattern/ResultExtension.cs
@@ -1,5 +1,9 @@
 namespace BlogDoFT.Libs.ResultPattern;
 
+/// <summary>
+/// Provides extension methods to terminate a <see cref="Result{TValue}"/> pipeline by
+/// executing a success or failure delegate and returning its produced value.
+/// </summary>
 public static class ResultExtension
 {
     /// <summary>

--- a/src/BlogDoFT.Libs.ResultPattern/TapFailureExtension.cs
+++ b/src/BlogDoFT.Libs.ResultPattern/TapFailureExtension.cs
@@ -1,5 +1,9 @@
 namespace BlogDoFT.Libs.ResultPattern;
 
+/// <summary>
+/// Provides extension methods to run side effects (e.g. logging, notifications) when a
+/// <see cref="Result{T}"/> represents a failure, without altering the result itself.
+/// </summary>
 public static class TapFailureExtension
 {
     /// <summary>

--- a/src/BlogDoFT.Libs.ResultPattern/ThenExtension.cs
+++ b/src/BlogDoFT.Libs.ResultPattern/ThenExtension.cs
@@ -1,5 +1,9 @@
 namespace BlogDoFT.Libs.ResultPattern;
 
+/// <summary>
+/// Provides extension methods to chain operations that each return a <see cref="Result{T}"/>,
+/// short-circuiting the chain as soon as a failure occurs.
+/// </summary>
 public static class ThenExtension
 {
     /// <summary>

--- a/src/BlogDoFT.Libs.WarmUp/Constants/WarmUpConstants.cs
+++ b/src/BlogDoFT.Libs.WarmUp/Constants/WarmUpConstants.cs
@@ -1,7 +1,17 @@
 namespace BlogDoFT.Libs.WarmUp.Constants;
 
+/// <summary>
+/// Provides constant values shared across the warm-up health check and its registration.
+/// </summary>
 public static class WarmUpConstants
 {
+    /// <summary>
+    /// The health check tag used to filter warm-up related health checks.
+    /// </summary>
     public const string Tag = "warmup";
+
+    /// <summary>
+    /// The name under which the warm-up health check is registered.
+    /// </summary>
     public const string WarmUpName = "warmup_startup_healthcheck";
 }

--- a/src/BlogDoFT.Libs.WarmUp/Extensions/WarmUpServiceExtension.cs
+++ b/src/BlogDoFT.Libs.WarmUp/Extensions/WarmUpServiceExtension.cs
@@ -15,9 +15,19 @@ using System.Text.Json;
 namespace BlogDoFT.Libs.WarmUp.Extensions;
 
 #pragma warning disable CA2254 // Template should be a static expression
+
+/// <summary>
+/// Provides extension methods to register and expose the application warm-up feature.
+/// </summary>
 [ExcludeFromCodeCoverage]
 public static class WarmUpServiceExtension
 {
+    /// <summary>
+    /// Registers the warm-up health check and hosted service, using an <see cref="ILoggerFactory"/> resolved
+    /// from <paramref name="services"/> to log warm-up progress.
+    /// </summary>
+    /// <param name="services">The service collection to add the warm-up registrations to.</param>
+    /// <returns>The same <see cref="IServiceCollection"/> instance, so calls can be chained.</returns>
     public static IServiceCollection AddWarmUp(
         this IServiceCollection services)
     {
@@ -33,6 +43,14 @@ public static class WarmUpServiceExtension
         return services.AddWarmUp(LogInfo, LogError, LogTrace);
     }
 
+    /// <summary>
+    /// Registers the warm-up health check and hosted service, using the supplied delegates to log warm-up progress.
+    /// </summary>
+    /// <param name="services">The service collection to add the warm-up registrations to.</param>
+    /// <param name="logInfo">The delegate used to log informational messages.</param>
+    /// <param name="logError">The delegate used to log error messages.</param>
+    /// <param name="logTrace">The delegate used to log trace messages.</param>
+    /// <returns>The same <see cref="IServiceCollection"/> instance, so calls can be chained.</returns>
     public static IServiceCollection AddWarmUp(
         this IServiceCollection services,
         Action<string> logInfo,
@@ -44,6 +62,11 @@ public static class WarmUpServiceExtension
             .ConfigureHealthCheck()
             .AddWarmServices(logInfo, logError, logTrace);
 
+    /// <summary>
+    /// Registers the warm-up health check with the health checks system, tagged so it can be filtered by <see cref="UseWarmUp"/>.
+    /// </summary>
+    /// <param name="services">The service collection to add the health check registration to.</param>
+    /// <returns>The same <see cref="IServiceCollection"/> instance, so calls can be chained.</returns>
     public static IServiceCollection ConfigureHealthCheck(
         this IServiceCollection services) =>
         services
@@ -54,6 +77,12 @@ public static class WarmUpServiceExtension
                     tags: [WarmUpConstants.Tag])
                 .Services;
 
+    /// <summary>
+    /// Maps a health check endpoint that reports the status of the warm-up health checks as JSON.
+    /// </summary>
+    /// <param name="app">The application builder to register the endpoint on.</param>
+    /// <param name="route">The route pattern at which the warm-up health check endpoint is exposed.</param>
+    /// <returns>The same <see cref="IApplicationBuilder"/> instance, so calls can be chained.</returns>
     public static IApplicationBuilder UseWarmUp(this IApplicationBuilder app, string route) =>
         app
             .UseHealthChecks(route, new HealthCheckOptions()

--- a/src/BlogDoFT.Libs.WarmUp/IWarmUpCommand.cs
+++ b/src/BlogDoFT.Libs.WarmUp/IWarmUpCommand.cs
@@ -1,6 +1,13 @@
 namespace BlogDoFT.Libs.WarmUp;
 
+/// <summary>
+/// Represents a command that performs application warm-up work, executed as part of the warm-up hosted service.
+/// </summary>
 public interface IWarmUpCommand
 {
+    /// <summary>
+    /// Executes the warm-up work for this command.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
     Task Execute();
 }


### PR DESCRIPTION
## Summary
- Adds `<summary>`, `<param>`, `<typeparam>`, `<returns>`, and `<exception>` XML documentation comments to every public (and protected) type and member across all `src/` library projects.
- Purely additive — no logic, formatting, or existing content was changed (43 files, 680 insertions, 2 deletions — the 2 deletions were empty `<returns></returns>` placeholders filled in with real descriptions).
- Where a member is an override or explicit interface implementation with no behavior change worth calling out, `<inheritdoc/>` is used instead of duplicating docs.

## Test plan
- [x] `dotnet build BlogDoFT.Libs.sln` — succeeds, 0 errors, only 1 pre-existing warning unrelated to this change
- [x] `dotnet test BlogDoFT.Libs.sln` — all 105 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)