### PR TITLE
fix: DI registration and connection-lifetime issues in WarmUp and DapperUtils.Postgres

### DIFF
--- a/BlogDoFT.Libs.sln
+++ b/BlogDoFT.Libs.sln
@@ -47,6 +47,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlogDoFT.Libs.Api.OpenTelem
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlogDoFT.Libs.Api.OpenTelemetry.Tests", "__tests__\BlogDoFT.Libs.Api.OpenTelemetry.Tests\BlogDoFT.Libs.Api.OpenTelemetry.Tests.csproj", "{B8C7B081-7FDC-4267-95C0-583B7CCF73A3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlogDoFT.Libs.EntityFramework.CodeGenerator.Tests", "__tests__\BlogDoFT.Libs.EntityFramework.CodeGenerator.Tests\BlogDoFT.Libs.EntityFramework.CodeGenerator.Tests.csproj", "{6A4C8C94-FC34-4098-BC14-6A279130AE03}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -297,6 +299,18 @@ Global
 		{B8C7B081-7FDC-4267-95C0-583B7CCF73A3}.Release|x64.Build.0 = Release|Any CPU
 		{B8C7B081-7FDC-4267-95C0-583B7CCF73A3}.Release|x86.ActiveCfg = Release|Any CPU
 		{B8C7B081-7FDC-4267-95C0-583B7CCF73A3}.Release|x86.Build.0 = Release|Any CPU
+		{6A4C8C94-FC34-4098-BC14-6A279130AE03}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A4C8C94-FC34-4098-BC14-6A279130AE03}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A4C8C94-FC34-4098-BC14-6A279130AE03}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6A4C8C94-FC34-4098-BC14-6A279130AE03}.Debug|x64.Build.0 = Debug|Any CPU
+		{6A4C8C94-FC34-4098-BC14-6A279130AE03}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6A4C8C94-FC34-4098-BC14-6A279130AE03}.Debug|x86.Build.0 = Debug|Any CPU
+		{6A4C8C94-FC34-4098-BC14-6A279130AE03}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A4C8C94-FC34-4098-BC14-6A279130AE03}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A4C8C94-FC34-4098-BC14-6A279130AE03}.Release|x64.ActiveCfg = Release|Any CPU
+		{6A4C8C94-FC34-4098-BC14-6A279130AE03}.Release|x64.Build.0 = Release|Any CPU
+		{6A4C8C94-FC34-4098-BC14-6A279130AE03}.Release|x86.ActiveCfg = Release|Any CPU
+		{6A4C8C94-FC34-4098-BC14-6A279130AE03}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -322,5 +336,6 @@ Global
 		{205E6D28-FE33-4583-B904-E8A034C980D5} = {79DEDDC6-6963-F508-0BD2-ED747C83B0CE}
 		{D5850FF8-F3CB-406F-9DF2-1F7F0623E666} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{B8C7B081-7FDC-4267-95C0-583B7CCF73A3} = {79DEDDC6-6963-F508-0BD2-ED747C83B0CE}
+		{6A4C8C94-FC34-4098-BC14-6A279130AE03} = {79DEDDC6-6963-F508-0BD2-ED747C83B0CE}
 	EndGlobalSection
 EndGlobal

--- a/__tests__/BlogDoFT.Libs.DapperUtils.Postgres.Tests/PostgresDatabaseFacadeTests.cs
+++ b/__tests__/BlogDoFT.Libs.DapperUtils.Postgres.Tests/PostgresDatabaseFacadeTests.cs
@@ -1,0 +1,73 @@
+using BlogDoFT.Libs.DapperUtils.Abstractions;
+using System.Data;
+
+namespace BlogDoFT.Libs.DapperUtils.Postgres.Tests;
+
+public class PostgresDatabaseFacadeTests
+{
+    [Fact]
+    public void Should_NotOpenConnection_When_Constructed()
+    {
+        // Given
+        var connection = Substitute.For<IDbConnection>();
+        var connectionFactory = Substitute.For<IConnectionFactory>();
+        connectionFactory.GetNewConnection().Returns(connection);
+
+        // When
+        using var facade = new PostgresDatabaseFacade(connectionFactory);
+
+        // Then
+        connection.DidNotReceive().Open();
+    }
+
+    [Fact]
+    public void Should_OpenConnection_When_GetDbConnectionIsCalledAndConnectionIsClosed()
+    {
+        // Given
+        var connection = Substitute.For<IDbConnection>();
+        connection.State.Returns(ConnectionState.Closed);
+        var connectionFactory = Substitute.For<IConnectionFactory>();
+        connectionFactory.GetNewConnection().Returns(connection);
+        using var facade = new PostgresDatabaseFacade(connectionFactory);
+
+        // When
+        var result = facade.GetDbConnection();
+
+        // Then
+        result.ShouldBeSameAs(connection);
+        connection.Received(1).Open();
+    }
+
+    [Fact]
+    public void Should_NotOpenConnection_When_GetDbConnectionIsCalledAndConnectionIsAlreadyOpen()
+    {
+        // Given
+        var connection = Substitute.For<IDbConnection>();
+        connection.State.Returns(ConnectionState.Open);
+        var connectionFactory = Substitute.For<IConnectionFactory>();
+        connectionFactory.GetNewConnection().Returns(connection);
+        using var facade = new PostgresDatabaseFacade(connectionFactory);
+
+        // When
+        facade.GetDbConnection();
+
+        // Then
+        connection.DidNotReceive().Open();
+    }
+
+    [Fact]
+    public void Should_DisposeConnection_When_FacadeIsDisposed()
+    {
+        // Given
+        var connection = Substitute.For<IDbConnection>();
+        var connectionFactory = Substitute.For<IConnectionFactory>();
+        connectionFactory.GetNewConnection().Returns(connection);
+        var facade = new PostgresDatabaseFacade(connectionFactory);
+
+        // When
+        facade.Dispose();
+
+        // Then
+        connection.Received(1).Dispose();
+    }
+}

--- a/__tests__/BlogDoFT.Libs.DomainNotifications.Tests/DomainNotificationExtensionTests.cs
+++ b/__tests__/BlogDoFT.Libs.DomainNotifications.Tests/DomainNotificationExtensionTests.cs
@@ -43,7 +43,7 @@ public sealed class DomainNotificationExtensionTests
         // Then
         returnedServices.ShouldBe(services);
         descriptor.ShouldNotBeNull();
-        descriptor!.ServiceType.ShouldBe(typeof(IDomainNotifications));
+        descriptor.ServiceType.ShouldBe(typeof(IDomainNotifications));
         descriptor.ImplementationType.ShouldBe(typeof(DomainNotificationBag));
         descriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
     }

--- a/__tests__/BlogDoFT.Libs.EntityFramework.CodeGenerator.Tests/BlogDoFT.Libs.EntityFramework.CodeGenerator.Tests.csproj
+++ b/__tests__/BlogDoFT.Libs.EntityFramework.CodeGenerator.Tests/BlogDoFT.Libs.EntityFramework.CodeGenerator.Tests.csproj
@@ -1,0 +1,62 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="Roslynator.Analyzers" Version="4.16.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Roslynator.CodeFixes" Version="4.16.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.16.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.33.0.1635">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\BlogDoFT.Libs.EntityFramework.CodeGenerator\BlogDoFT.Libs.EntityFramework.CodeGenerator.csproj" />
+    <ProjectReference Include="..\..\src\BlogDoFT.Libs.EntityFramework.CodeGenerator.Abstractions\BlogDoFT.Libs.EntityFramework.CodeGenerator.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/__tests__/BlogDoFT.Libs.EntityFramework.CodeGenerator.Tests/GeneratorTestHelper.cs
+++ b/__tests__/BlogDoFT.Libs.EntityFramework.CodeGenerator.Tests/GeneratorTestHelper.cs
@@ -1,0 +1,73 @@
+using BlogDoFT.Libs.EntityFramework.CodeGenerator.Abstractions.PredicateGenerators;
+using BlogDoFT.Libs.EntityFramework.CodeGenerator.Generators;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using System.Collections.Immutable;
+using System.Linq.Expressions;
+
+namespace BlogDoFT.Libs.EntityFramework.CodeGenerator.Tests;
+
+internal static class GeneratorTestHelper
+{
+    public static GeneratorRunResult Run(string source)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest));
+
+        // Force the assemblies the generated/annotated source depends on to be loaded into the
+        // current AppDomain before snapshotting it below (they may not be loaded yet otherwise,
+        // since nothing in this test assembly's own IL references their types directly).
+        _ = typeof(object).Assembly;
+        _ = typeof(Enumerable).Assembly;
+        _ = typeof(Expression).Assembly;
+        _ = typeof(ComparisonOperator).Assembly;
+
+        var references = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(assembly => !assembly.IsDynamic && !string.IsNullOrWhiteSpace(assembly.Location))
+            .Select(assembly => (MetadataReference)MetadataReference.CreateFromFile(assembly.Location))
+            .ToList();
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: "GeneratorTests",
+            syntaxTrees: [syntaxTree],
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var generator = new PredicateGenerator();
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(generator);
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out _);
+
+        var generatedTrees = outputCompilation.SyntaxTrees
+            .Where(tree => tree.FilePath.EndsWith(".g.cs", StringComparison.Ordinal))
+            .ToImmutableArray();
+
+        // Diagnostics from actually compiling the output (source + generated trees together), so tests
+        // can assert the emitted code is valid C# and not just that the generator didn't throw.
+        var compilationErrors = outputCompilation.GetDiagnostics()
+            .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .ToImmutableArray();
+
+        return new GeneratorRunResult(driver.GetRunResult().Diagnostics, generatedTrees, compilationErrors);
+    }
+}
+
+internal sealed class GeneratorRunResult
+{
+    public GeneratorRunResult(ImmutableArray<Diagnostic> diagnostics, ImmutableArray<SyntaxTree> generatedTrees, ImmutableArray<Diagnostic> compilationErrors)
+    {
+        Diagnostics = diagnostics;
+        GeneratedTrees = generatedTrees;
+        CompilationErrors = compilationErrors;
+    }
+
+    public ImmutableArray<Diagnostic> Diagnostics { get; }
+
+    public ImmutableArray<SyntaxTree> GeneratedTrees { get; }
+
+    /// <summary>Error-severity diagnostics from compiling the source together with the generated trees.</summary>
+    public ImmutableArray<Diagnostic> CompilationErrors { get; }
+
+    public string? GeneratedSourceEndingWith(string suffix) =>
+        GeneratedTrees.FirstOrDefault(tree => tree.FilePath.EndsWith(suffix, StringComparison.Ordinal))?.ToString();
+
+    public bool HasDiagnostic(string id) => Diagnostics.Any(diagnostic => diagnostic.Id == id);
+}

--- a/__tests__/BlogDoFT.Libs.EntityFramework.CodeGenerator.Tests/PredicateGeneratorTests.cs
+++ b/__tests__/BlogDoFT.Libs.EntityFramework.CodeGenerator.Tests/PredicateGeneratorTests.cs
@@ -1,0 +1,301 @@
+using Shouldly;
+
+namespace BlogDoFT.Libs.EntityFramework.CodeGenerator.Tests;
+
+public class PredicateGeneratorTests
+{
+    [Fact]
+    public void GivenDtoWithFilterableProperties_WhenGenerating_ThenEmitsPublicPredicateWithoutWarnings()
+    {
+        const string Source = """
+            using BlogDoFT.Libs.EntityFramework.CodeGenerator.Abstractions.PredicateGenerators;
+
+            namespace TestNamespace;
+
+            public class Entity
+            {
+                public string? Name { get; set; }
+            }
+
+            [GeneratePredicate<Entity>]
+            public partial class EntityFilter
+            {
+                [StringFilter(TargetProperty = nameof(Entity.Name))]
+                public string? Name { get; set; }
+            }
+            """;
+
+        var result = GeneratorTestHelper.Run(Source);
+
+        result.HasDiagnostic("PG004").ShouldBeFalse();
+        result.HasDiagnostic("PG101").ShouldBeFalse();
+        result.HasDiagnostic("PG900").ShouldBeFalse();
+        result.CompilationErrors.ShouldBeEmpty();
+
+        var generated = result.GeneratedSourceEndingWith("EntityFilter_ToPredicate.g.cs");
+        generated.ShouldNotBeNull();
+        generated.ShouldContain("public Expression<Func<Entity, bool>> ToPredicate()");
+    }
+
+    [Fact]
+    public void GivenNumericFilterWithOrderingOperator_WhenGenerating_ThenEmitsCompilableNamedOperatorSwitch()
+    {
+        const string Source = """
+            using BlogDoFT.Libs.EntityFramework.CodeGenerator.Abstractions.PredicateGenerators;
+
+            namespace TestNamespace;
+
+            public class Entity
+            {
+                public int Age { get; set; }
+            }
+
+            [GeneratePredicate<Entity>]
+            public partial class EntityFilter
+            {
+                [NumericFilter(TargetProperty = nameof(Entity.Age), Operator = ComparisonOperator.GreaterThanOrEqual)]
+                public int? MinimumAge { get; set; }
+            }
+            """;
+
+        var result = GeneratorTestHelper.Run(Source);
+
+        result.HasDiagnostic("PG005").ShouldBeFalse();
+        result.CompilationErrors.ShouldBeEmpty();
+
+        var generated = result.GeneratedSourceEndingWith("EntityFilter_ToPredicate.g.cs");
+        generated.ShouldNotBeNull();
+        generated.ShouldContain("using BlogDoFT.Libs.EntityFramework.CodeGenerator.Abstractions.PredicateGenerators;");
+        generated.ShouldContain("ComparisonOperator operatorValue) =>");
+        generated.ShouldContain("BuildComparison(targetMember, right, ComparisonOperator.GreaterThanOrEqual);");
+        generated.ShouldContain("ComparisonOperator.GreaterThan => Expression.GreaterThan(left, right),");
+    }
+
+    [Fact]
+    public void GivenDtoWithNoFilterableProperties_WhenGenerating_ThenReportsPG004()
+    {
+        const string Source = """
+            using BlogDoFT.Libs.EntityFramework.CodeGenerator.Abstractions.PredicateGenerators;
+
+            namespace TestNamespace;
+
+            public class Entity
+            {
+                public string? Name { get; set; }
+            }
+
+            [GeneratePredicate<Entity>]
+            public partial class EmptyFilter
+            {
+                public string? NotAFilter { get; set; }
+            }
+            """;
+
+        var result = GeneratorTestHelper.Run(Source);
+
+        result.HasDiagnostic("PG004").ShouldBeTrue();
+        result.CompilationErrors.ShouldBeEmpty();
+
+        var generated = result.GeneratedSourceEndingWith("EmptyFilter_ToPredicate.g.cs");
+        generated.ShouldNotBeNull();
+        generated.ShouldContain("return false;");
+        generated.ShouldContain("return entity => true;");
+    }
+
+    [Fact]
+    public void GivenInternalEntity_WhenGenerating_ThenReportsPG101AndEmitsInternalMembers()
+    {
+        const string Source = """
+            using BlogDoFT.Libs.EntityFramework.CodeGenerator.Abstractions.PredicateGenerators;
+
+            namespace TestNamespace;
+
+            internal class Entity
+            {
+                public string? Name { get; set; }
+            }
+
+            [GeneratePredicate<Entity>]
+            public partial class EntityFilter
+            {
+                [StringFilter(TargetProperty = nameof(Entity.Name))]
+                public string? Name { get; set; }
+            }
+            """;
+
+        var result = GeneratorTestHelper.Run(Source);
+
+        result.HasDiagnostic("PG101").ShouldBeTrue();
+        result.CompilationErrors.ShouldBeEmpty();
+
+        var generated = result.GeneratedSourceEndingWith("EntityFilter_ToPredicate.g.cs");
+        generated.ShouldNotBeNull();
+        generated.ShouldContain("internal Expression<Func<Entity, bool>> ToPredicate()");
+    }
+
+    [Fact]
+    public void GivenNonPartialDto_WhenGenerating_ThenReportsPG001AndEmitsNoSource()
+    {
+        const string Source = """
+            using BlogDoFT.Libs.EntityFramework.CodeGenerator.Abstractions.PredicateGenerators;
+
+            namespace TestNamespace;
+
+            public class Entity
+            {
+                public string? Name { get; set; }
+            }
+
+            [GeneratePredicate<Entity>]
+            public class NotPartialFilter
+            {
+                [StringFilter(TargetProperty = nameof(Entity.Name))]
+                public string? Name { get; set; }
+            }
+            """;
+
+        var result = GeneratorTestHelper.Run(Source);
+
+        result.HasDiagnostic("PG001").ShouldBeTrue();
+        result.GeneratedSourceEndingWith("NotPartialFilter_ToPredicate.g.cs").ShouldBeNull();
+        result.CompilationErrors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenClassWithoutGeneratePredicateAttribute_WhenGenerating_ThenProducesNoOutput()
+    {
+        const string Source = """
+            namespace TestNamespace;
+
+            public partial class PlainClass
+            {
+                public string? Name { get; set; }
+            }
+            """;
+
+        var result = GeneratorTestHelper.Run(Source);
+
+        result.Diagnostics.ShouldBeEmpty();
+        result.GeneratedTrees.ShouldBeEmpty();
+        result.CompilationErrors.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void GivenUnresolvableEntityType_WhenGenerating_ThenReportsPG010AndEmitsNoSource()
+    {
+        const string Source = """
+            using BlogDoFT.Libs.EntityFramework.CodeGenerator.Abstractions.PredicateGenerators;
+
+            namespace TestNamespace;
+
+            [GeneratePredicate<DoesNotExist>]
+            public partial class EntityFilter
+            {
+                public string? Name { get; set; }
+            }
+            """;
+
+        var result = GeneratorTestHelper.Run(Source);
+
+        result.HasDiagnostic("PG010").ShouldBeTrue();
+        result.GeneratedSourceEndingWith("EntityFilter_ToPredicate.g.cs").ShouldBeNull();
+    }
+
+    [Fact]
+    public void GivenInvalidTargetPropertyPath_WhenGenerating_ThenReportsPG002AndSkipsThatFilter()
+    {
+        const string Source = """
+            using BlogDoFT.Libs.EntityFramework.CodeGenerator.Abstractions.PredicateGenerators;
+
+            namespace TestNamespace;
+
+            public class Entity
+            {
+                public string? Name { get; set; }
+            }
+
+            [GeneratePredicate<Entity>]
+            public partial class EntityFilter
+            {
+                [StringFilter(TargetProperty = "DoesNotExist")]
+                public string? Name { get; set; }
+            }
+            """;
+
+        var result = GeneratorTestHelper.Run(Source);
+
+        result.HasDiagnostic("PG002").ShouldBeTrue();
+        result.CompilationErrors.ShouldBeEmpty();
+
+        var generated = result.GeneratedSourceEndingWith("EntityFilter_ToPredicate.g.cs");
+        generated.ShouldNotBeNull();
+        generated.ShouldContain("return entity => true;");
+    }
+
+    [Fact]
+    public void GivenUnsupportedFilterAttribute_WhenGenerating_ThenReportsPG003AndIgnoresIt()
+    {
+        const string Source = """
+            using BlogDoFT.Libs.EntityFramework.CodeGenerator.Abstractions.PredicateGenerators;
+
+            namespace TestNamespace;
+
+            public sealed class GuidFilterAttribute : System.Attribute
+            {
+                public string? TargetProperty { get; set; }
+            }
+
+            public class Entity
+            {
+                public System.Guid Id { get; set; }
+            }
+
+            [GeneratePredicate<Entity>]
+            public partial class EntityFilter
+            {
+                [GuidFilter(TargetProperty = nameof(Entity.Id))]
+                public System.Guid? Id { get; set; }
+            }
+            """;
+
+        var result = GeneratorTestHelper.Run(Source);
+
+        result.HasDiagnostic("PG003").ShouldBeTrue();
+        result.CompilationErrors.ShouldBeEmpty();
+
+        var generated = result.GeneratedSourceEndingWith("EntityFilter_ToPredicate.g.cs");
+        generated.ShouldNotBeNull();
+        generated.ShouldContain("return entity => true;");
+    }
+
+    [Fact]
+    public void GivenOrderingOperatorOnNonOrderableTargetMember_WhenGenerating_ThenReportsPG005AndSkipsThatFilter()
+    {
+        const string Source = """
+            using BlogDoFT.Libs.EntityFramework.CodeGenerator.Abstractions.PredicateGenerators;
+
+            namespace TestNamespace;
+
+            public class Entity
+            {
+                public string? Name { get; set; }
+            }
+
+            [GeneratePredicate<Entity>]
+            public partial class EntityFilter
+            {
+                [NumericFilter(TargetProperty = nameof(Entity.Name), Operator = ComparisonOperator.GreaterThan)]
+                public int? NameFilter { get; set; }
+            }
+            """;
+
+        var result = GeneratorTestHelper.Run(Source);
+
+        result.HasDiagnostic("PG005").ShouldBeTrue();
+        result.CompilationErrors.ShouldBeEmpty();
+
+        var generated = result.GeneratedSourceEndingWith("EntityFilter_ToPredicate.g.cs");
+        generated.ShouldNotBeNull();
+        generated.ShouldContain("return entity => true;");
+    }
+}

--- a/__tests__/BlogDoFT.Libs.WarmUp.Tests/Extensions/WarmUpServiceExtensionTests.cs
+++ b/__tests__/BlogDoFT.Libs.WarmUp.Tests/Extensions/WarmUpServiceExtensionTests.cs
@@ -1,0 +1,39 @@
+using BlogDoFT.Libs.WarmUp.Extensions;
+using BlogDoFT.Libs.WarmUp.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BlogDoFT.Libs.WarmUp.Tests.Extensions;
+
+public class WarmUpServiceExtensionTests
+{
+    [Fact]
+    public void Should_NotThrow_When_RegisteringWithoutAnILoggerFactoryAlreadyResolvable()
+    {
+        // Given
+        var services = new ServiceCollection();
+
+        // When
+        var act = () => services.AddWarmUp();
+
+        // Then
+        Should.NotThrow(act);
+    }
+
+    [Fact]
+    public void Should_ResolveWarmUpCommands_When_ProviderIsBuiltAfterRegistration()
+    {
+        // Given
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddWarmUp();
+
+        // When
+        using var provider = services.BuildServiceProvider();
+        var preloading = provider.GetRequiredService<PreloadingCommand>();
+        var warmUpExecutor = provider.GetRequiredService<WarmUpExecutor>();
+
+        // Then
+        preloading.ShouldNotBeNull();
+        warmUpExecutor.ShouldNotBeNull();
+    }
+}

--- a/analysis.md
+++ b/analysis.md
@@ -1,0 +1,60 @@
+# Architecture & Design Review — BlogDoFT.Libs
+
+Consolidated review across all 11 library projects under `src/`, prioritized by impact.
+
+## 🔴 High-impact design flaws (will bite in production)
+
+**WarmUp's "warm up" doesn't actually wait for warm-up** — `WarmUpExecutor.Execute()` and `PreloadingCommand.Execute()` return `Task.CompletedTask` while the real work runs in a detached, unawaited `Task.Run`. `WarmUpHostedService`'s `await preloading.Execute(); await warmUpExecutor.Execute();` looks sequential but isn't — both background jobs actually race against each other and against the app becoming "ready." (`WarmUpExecutor.cs:26-49`, `PreloadingCommand.cs:23-41`)
+
+**EF source generator's error-reporting story is fake** — 8 of the 9 `DiagnosticDescriptor`s (`TargetPropertyPathInvalid`, `UnsupportedFilterAttribute`, `EntityTypeNotResolved`, etc.) are never actually reported anywhere in `PredicateGenerator.cs` — only `FilterDtoMustBePartial` is used. Invalid attribute usage currently produces silently wrong or non-compiling generated code instead of a build-time diagnostic, which defeats the whole point of a source generator's fail-safe design.
+
+**`ComparisonOperator` handling can silently generate wrong code** — the generator hardcodes the enum as raw `int` literals (`case 0..4`) in a switch disconnected from `Abstractions.ComparisonOperator`, with an unknown value silently falling back to `Equal`. Adding a new operator compiles fine and generates incorrect filters with no warning. (`PredicateGenerator.cs:193-204`)
+
+**`WarmUpServiceExtension.AddWarmUp` builds a provider mid-registration** — calls `services.BuildServiceProvider()` just to grab an `ILoggerFactory`, then discards it — the classic ASP0000 anti-pattern against a partially-configured container. It also reinvents logging via `Action<string>` delegates instead of `ILogger<T>`, requiring `CA2254` to be suppressed project-wide.
+
+**`PostgresDatabaseFacade` opens a DB connection synchronously in its constructor**, and it's registered `Scoped` — every scope creation blocks on a live round-trip whether or not the facade is used, in an otherwise fully-async API.
+
+## 🟠 Competing patterns causing real confusion
+
+**`Result<T>` and `IDomainNotifications` are two overlapping "did this fail and why" mechanisms**, and the sample app proves it's confusing in practice: `SalesCreate`/`SalesQuery` write every failure into the notifications bag (`.TapFailure(_notifications.Add)`), but `SalesController` builds its entire HTTP response from the returned `Result` alone — the notifications bag is **never read**. It's a dead side channel that exists only because `Failure` (ResultPattern) and `DomainNotification` (DomainNotifications) duplicate the same "code + message" concept with different nullability contracts, forcing an entire bridge project (`DomainNotifications.Extensions`) just to convert between them.
+
+## 🟡 Leaky abstractions / layering
+
+- `DapperUtils.Abstractions` directly depends on the `Dapper` package and wraps `Dapper.SqlMapper.GridReader` — it isn't actually ORM-agnostic despite the name.
+- `WhereBuilder` and `OrderByResolver` emit 100% vendor-neutral ANSI SQL but live in `DapperUtils.Postgres`, not `.Abstractions` — a future SQL Server provider can't reuse them.
+- `NpgConnectionFactory` re-registers Dapper's global type handlers on *every* `GetNewConnection()` call, and hardcodes the connection-string key and schema (`"public"`) with no override hook.
+- `DapperUtils.Postgres` (a low-level, provider-specific package) depends sideways on the generic `BlogDoFT.Libs.Extensions` grab-bag.
+- `PreloadingCommand.GetServices()` resolves **every** registered service in the container at startup — a blunt, hidden side effect with no opt-in list; combined with `WarmUpExecutor`'s reflection over the build-time `IServiceCollection`, WarmUp implements a service-locator pattern instead of idiomatic `IEnumerable<IWarmUpCommand>` DI resolution.
+
+## 🟢 Extensibility (Open/Closed violations)
+
+- `PredicateGenerator` is a single 359-line class mixing pipeline wiring, symbol analysis, and string-builder code emission with no seam for unit testing without running the full Roslyn pipeline.
+- Filter-kind dispatch is a hardcoded `if/else` chain on attribute name string, not pluggable — adding a 5th filter attribute means editing this core method.
+- The generator identifies `[GeneratePredicate<T>]` via `attributeClass.Name.StartsWith(...)` rather than resolving the real symbol — a same-named unrelated attribute would false-positive match.
+
+## 🔵 Solution-level structure
+
+- **Lockstep versioning**: CI stamps every one of the 11 independently-packable NuGet packages with the same GitVersion output on every publish — a one-line fix in `WarmUp` republishes all 11 packages under an identical version bump, misleading consumers about what actually changed.
+- **Test coverage blind spot**: `EntityFramework.CodeGenerator` and its `.Abstractions` project have *no* test project at all — exactly the code (a source generator) where design regressions go unnoticed silently. `BlogDoFT.Libs.Api.Tests` exists in the solution but contains zero actual tests, a stub giving false CI confidence.
+- **Samples under-exercise the library set**: the WebApi sample only wires up `ResultPattern`/`DomainNotifications`/`Extensions`; `Api`, `Api.OpenTelemetry`, `DapperUtils.*`, and `WarmUp` have no real "how do I wire this into an app" reference anywhere in the repo — including the WarmUp sequencing bug and the OTel `UseOpenTelemetry` silent-no-op-on-wrong-type issue below, neither of which would ever surface in the repo's own sample.
+
+## ⚪ Minor / API contract inconsistencies
+
+- `EnumExtensions.ToEnum<TEnum>` throws `InvalidCastException` on a parse failure — semantically should be `FormatException`/`ArgumentException` per `Enum.Parse` convention, so consumers catching the idiomatic exception type will miss it.
+- `StringExtensions.ReplaceAll` recurses with no cycle guard — if `newString` contains `oldString` (e.g. replacing `"a"` with `"aa"`), it recurses until stack overflow.
+- `ResultException.CallFailureOnSuccess()` is defined but never invoked, and `Result<TValue>.Value`'s success/failure guard uses `ReferenceEquals(Failure, Failure.None)` while `IsFailure` uses record value equality — two different, inconsistent ways of enforcing the same "IsSuccess implies Value is safe" invariant. A hand-built `Failure` equal-by-value to `None` but not reference-equal would report `IsSuccess == true` yet still throw on `.Value`.
+- `PostgresDatabaseFacade.QueryFirstAsync<T>` exists on the concrete internal class but isn't declared on `IDatabaseFacade` — since the class is `internal`, this is unreachable dead API surface.
+- `OpenTelemetryExtension.UseOpenTelemetry` does `(app as IEndpointRouteBuilder)?.MapPrometheusScrapingEndpoint()` — a silent no-op if the caller passes a plain `IApplicationBuilder` rather than `WebApplication`, with no error or log on misconfiguration.
+- `Observability` manually parses `IConfiguration` in its constructor and is registered via `AddSingleton(Options.Create(...))`, bypassing the standard `services.Configure<T>()`/`IOptionsMonitor`/`IValidateOptions` pipeline, while exposing mutable `{ get; set; }` properties on what's effectively shared singleton state.
+
+## What's actually solid
+
+- Project dependency graph has no cycles or inverted references (`Postgres → Abstractions`, `CodeGenerator → CodeGenerator.Abstractions` both flow correctly).
+- `IConnectionFactory`/`IDatabaseFacade`/`IGridReaderFacade` are narrow, mockable interfaces (good ISP).
+- `Then`/`Map`/`Tap`/`TapFailure` in ResultPattern correctly and consistently short-circuit on failure — solid monadic composition.
+- `EntityFramework.CodeGenerator.Abstractions` attributes are pure markers with zero generator logic leaking in — clean split.
+- `Api` vs `Extensions` split is justified (framework-dependent vs. framework-agnostic), not arbitrary.
+
+---
+
+*Next step suggestion: the WarmUp sequencing bug and the dead diagnostics in the source generator are probably the highest-value places to start fixing.*

--- a/src/BlogDoFT.Libs.Api.OpenTelemetry/Extensions/OpenTelemetryExtension.cs
+++ b/src/BlogDoFT.Libs.Api.OpenTelemetry/Extensions/OpenTelemetryExtension.cs
@@ -152,7 +152,7 @@ public static class OpenTelemetryExtension
                         }
 
                         tracing.ConfigureServices(services =>
-                            services.AddSingleton(Options.Create(observability.ZipkinExporterOptions!)));
+                            services.AddSingleton(Options.Create(observability.ZipkinExporterOptions)));
 
                         tracing.AddZipkinExporter();
                         break;

--- a/src/BlogDoFT.Libs.Api/Extensions/HttpHeaderExtension.cs
+++ b/src/BlogDoFT.Libs.Api/Extensions/HttpHeaderExtension.cs
@@ -43,7 +43,7 @@ public static class HttpHeaderExtension
             host = httpRequest.Host.Value;
         }
 
-        return host!;
+        return host;
     }
 
     /// <summary>

--- a/src/BlogDoFT.Libs.DapperUtils.Postgres/PostgresDatabaseFacade.cs
+++ b/src/BlogDoFT.Libs.DapperUtils.Postgres/PostgresDatabaseFacade.cs
@@ -2,6 +2,7 @@ using BlogDoFT.Libs.DapperUtils.Abstractions;
 using BlogDoFT.Libs.DapperUtils.Abstractions.Impl;
 using Dapper;
 using System.Data;
+using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
 
 namespace BlogDoFT.Libs.DapperUtils.Postgres;
@@ -16,36 +17,75 @@ internal class PostgresDatabaseFacade : IDatabaseFacade
     public PostgresDatabaseFacade(IConnectionFactory connectionFactory)
     {
         _connection = connectionFactory.GetNewConnection();
-        _connection.Open();
     }
 
     public void Dispose() =>
         _connection.Dispose();
 
-    public Task<IEnumerable<T>> QueryAsync<T>(
+    public async Task<IEnumerable<T>> QueryAsync<T>(
         string sql,
-        object? param = null) =>
-        _connection.QueryAsync<T>(sql, param);
+        object? param = null)
+    {
+        await EnsureOpenAsync();
+        return await _connection.QueryAsync<T>(sql, param);
+    }
 
     public async Task<T> QueryFirstAsync<T>(
         string sql,
-        object? param = null) =>
-        await _connection.QueryFirstAsync<T>(sql, param);
+        object? param = null)
+    {
+        await EnsureOpenAsync();
+        return await _connection.QueryFirstAsync<T>(sql, param);
+    }
 
-    public async Task<int> ExecuteAsync(string sql, object? param = null, IDbTransaction? transaction = null) =>
-        await _connection.ExecuteAsync(sql, param, transaction);
+    public async Task<int> ExecuteAsync(string sql, object? param = null, IDbTransaction? transaction = null)
+    {
+        await EnsureOpenAsync();
+        return await _connection.ExecuteAsync(sql, param, transaction);
+    }
 
-    public async Task<TReturn?> ExecuteScalarAsync<TReturn>(string sql, object? param = null, IDbTransaction? transaction = null) =>
-        await _connection.ExecuteScalarAsync<TReturn>(sql, param, transaction);
+    public async Task<TReturn?> ExecuteScalarAsync<TReturn>(string sql, object? param = null, IDbTransaction? transaction = null)
+    {
+        await EnsureOpenAsync();
+        return await _connection.ExecuteScalarAsync<TReturn>(sql, param, transaction);
+    }
 
     public async Task<IGridReaderFacade> QueryMultipleAsync(string sql, object? param)
     {
+        await EnsureOpenAsync();
         var multiple = await _connection.QueryMultipleAsync(sql, param);
         return new GridReaderFacade(multiple);
     }
 
-    public async Task<T?> QuerySingleOrDefaultAsync<T>(string sql, object? param = null) =>
-        await _connection.QuerySingleOrDefaultAsync<T>(sql, param);
+    public async Task<T?> QuerySingleOrDefaultAsync<T>(string sql, object? param = null)
+    {
+        await EnsureOpenAsync();
+        return await _connection.QuerySingleOrDefaultAsync<T>(sql, param);
+    }
 
-    public IDbConnection GetDbConnection() => _connection;
+    public IDbConnection GetDbConnection()
+    {
+        if (_connection.State != ConnectionState.Open)
+        {
+            _connection.Open();
+        }
+
+        return _connection;
+    }
+
+    private async Task EnsureOpenAsync(CancellationToken cancellationToken = default)
+    {
+        if (_connection.State == ConnectionState.Open)
+        {
+            return;
+        }
+
+        if (_connection is DbConnection adoConnection)
+        {
+            await adoConnection.OpenAsync(cancellationToken);
+            return;
+        }
+
+        _connection.Open();
+    }
 }

--- a/src/BlogDoFT.Libs.EntityFramework.CodeGenerator/Generators/PredicateGenerator.cs
+++ b/src/BlogDoFT.Libs.EntityFramework.CodeGenerator/Generators/PredicateGenerator.cs
@@ -50,9 +50,19 @@ namespace BlogDoFT.Libs.EntityFramework.CodeGenerator.Generators
                         }
 
                         var entityTypeSymbol = generateAttribute.AttributeClass!.TypeArguments[0] as INamedTypeSymbol;
-                        if (entityTypeSymbol is null)
+                        if (entityTypeSymbol is null || entityTypeSymbol.TypeKind == TypeKind.Error)
                         {
-                            return default(PredicateCandidate);
+                            var unresolvedEntityDiagnostic = DiagnosticDescriptors.Create(
+                                DiagnosticDescriptors.EntityTypeNotResolved,
+                                filterTypeSymbol,
+                                filterTypeSymbol.Name);
+
+                            return new PredicateCandidate(
+                                filterType: filterTypeSymbol,
+                                entityType: null,
+                                isPartial: false,
+                                properties: Array.Empty<FilterProperty>(),
+                                diagnostics: new[] { unresolvedEntityDiagnostic });
                         }
 
                         var isPartial = classDeclaration.Modifiers.Any(m => m.Text == "partial");
@@ -63,6 +73,7 @@ namespace BlogDoFT.Libs.EntityFramework.CodeGenerator.Generators
                             .ToArray();
 
                         var collectedFilters = new List<FilterProperty>();
+                        var propertyDiagnostics = new List<Diagnostic>();
 
                         foreach (var property in propertySymbols)
                         {
@@ -91,6 +102,34 @@ namespace BlogDoFT.Libs.EntityFramework.CodeGenerator.Generators
                                         }
                                     }
 
+                                    var targetPropertyPath = targetProperty ?? property.Name;
+                                    var resolvedTargetProperty = ResolveTargetProperty(entityTypeSymbol, targetPropertyPath);
+
+                                    if (resolvedTargetProperty is null)
+                                    {
+                                        propertyDiagnostics.Add(DiagnosticDescriptors.Create(
+                                            DiagnosticDescriptors.TargetPropertyPathInvalid,
+                                            property,
+                                            property.Name,
+                                            filterTypeSymbol.Name,
+                                            targetPropertyPath,
+                                            entityTypeSymbol.Name));
+
+                                        continue;
+                                    }
+
+                                    if (comparisonOperator is >= 1 and <= 4 && !SupportsOrdering(resolvedTargetProperty.Type))
+                                    {
+                                        propertyDiagnostics.Add(DiagnosticDescriptors.Create(
+                                            DiagnosticDescriptors.ComparisonOperatorNotApplicable,
+                                            property,
+                                            property.Name,
+                                            filterTypeSymbol.Name,
+                                            targetPropertyPath));
+
+                                        continue;
+                                    }
+
                                     var declarationOrder = GetDeclarationOrder(property);
 
                                     collectedFilters.Add(new FilterProperty(
@@ -101,6 +140,15 @@ namespace BlogDoFT.Libs.EntityFramework.CodeGenerator.Generators
                                         comparisonOperator: comparisonOperator,
                                         declarationOrder: declarationOrder));
                                 }
+                                else if (attributeName is not null && attributeName.EndsWith("FilterAttribute", StringComparison.Ordinal))
+                                {
+                                    propertyDiagnostics.Add(DiagnosticDescriptors.Create(
+                                        DiagnosticDescriptors.UnsupportedFilterAttribute,
+                                        property,
+                                        property.Name,
+                                        filterTypeSymbol.Name,
+                                        attributeName));
+                                }
                             }
                         }
 
@@ -108,26 +156,66 @@ namespace BlogDoFT.Libs.EntityFramework.CodeGenerator.Generators
                             filterType: filterTypeSymbol,
                             entityType: entityTypeSymbol,
                             isPartial: isPartial,
-                            properties: collectedFilters);
+                            properties: collectedFilters,
+                            diagnostics: propertyDiagnostics);
                     })
-                .Where(candidate => candidate.FilterType is not null && candidate.EntityType is not null);
+                .Where(candidate => candidate.FilterType is not null);
 
             context.RegisterSourceOutput(candidates, static (productionContext, candidate) =>
             {
-                if (!candidate.IsPartial)
+                try
                 {
-                    var diagnostic = DiagnosticDescriptors.Create(
-                        DiagnosticDescriptors.FilterDtoMustBePartial,
-                        candidate.FilterType,
-                        candidate.FilterType!.Name);
+                    foreach (var diagnostic in candidate.Diagnostics)
+                    {
+                        productionContext.ReportDiagnostic(diagnostic);
+                    }
 
-                    productionContext.ReportDiagnostic(diagnostic);
+                    if (candidate.EntityType is null)
+                    {
+                        return;
+                    }
 
-                    return;
+                    if (!candidate.IsPartial)
+                    {
+                        var diagnostic = DiagnosticDescriptors.Create(
+                            DiagnosticDescriptors.FilterDtoMustBePartial,
+                            candidate.FilterType,
+                            candidate.FilterType!.Name);
+
+                        productionContext.ReportDiagnostic(diagnostic);
+
+                        return;
+                    }
+
+                    var result = GenerateSource(candidate);
+
+                    if (!result.HasFilterableProperties)
+                    {
+                        productionContext.ReportDiagnostic(DiagnosticDescriptors.Create(
+                            DiagnosticDescriptors.NoFilterablePropertiesFound,
+                            candidate.FilterType,
+                            candidate.FilterType!.Name));
+                    }
+
+                    if (result.IsInternal)
+                    {
+                        productionContext.ReportDiagnostic(DiagnosticDescriptors.Create(
+                            DiagnosticDescriptors.GeneratedMembersSetToInternal,
+                            candidate.FilterType,
+                            candidate.EntityType!.Name,
+                            candidate.FilterType!.Name));
+                    }
+
+                    productionContext.AddSource($"{candidate.FilterType!.Name}_ToPredicate.g.cs", result.Source);
                 }
-
-                var source = GenerateSource(candidate);
-                productionContext.AddSource($"{candidate.FilterType!.Name}_ToPredicate.g.cs", source);
+                catch (Exception exception)
+                {
+                    productionContext.ReportDiagnostic(DiagnosticDescriptors.Create(
+                        DiagnosticDescriptors.UnexpectedGenerationFailure,
+                        candidate.FilterType,
+                        candidate.FilterType?.Name ?? "unknown",
+                        exception.Message));
+                }
             });
         }
 
@@ -140,7 +228,96 @@ namespace BlogDoFT.Libs.EntityFramework.CodeGenerator.Generators
             return span.StartLinePosition.Line * 1000 + span.StartLinePosition.Character;
         }
 
-        private static string GenerateSource(PredicateCandidate candidate)
+        private static IPropertySymbol? ResolveTargetProperty(INamedTypeSymbol entityType, string path)
+        {
+            ITypeSymbol currentType = entityType;
+            IPropertySymbol? resolved = null;
+
+            foreach (var segment in path.Split('.'))
+            {
+                resolved = FindPublicProperty(currentType, segment);
+                if (resolved is null)
+                {
+                    return null;
+                }
+
+                currentType = resolved.Type;
+            }
+
+            return resolved;
+        }
+
+        private static IPropertySymbol? FindPublicProperty(ITypeSymbol type, string name)
+        {
+            for (var current = type; current is not null; current = current.BaseType)
+            {
+                var match = current.GetMembers(name)
+                    .OfType<IPropertySymbol>()
+                    .FirstOrDefault(p => p.DeclaredAccessibility == Accessibility.Public && p.GetMethod is not null);
+
+                if (match is not null)
+                {
+                    return match;
+                }
+            }
+
+            return null;
+        }
+
+        private static bool SupportsOrdering(ITypeSymbol type)
+        {
+            var underlying = UnwrapNullable(type);
+
+            if (underlying.TypeKind == TypeKind.Enum)
+            {
+                return true;
+            }
+
+            switch (underlying.SpecialType)
+            {
+                case SpecialType.System_SByte:
+                case SpecialType.System_Byte:
+                case SpecialType.System_Int16:
+                case SpecialType.System_UInt16:
+                case SpecialType.System_Int32:
+                case SpecialType.System_UInt32:
+                case SpecialType.System_Int64:
+                case SpecialType.System_UInt64:
+                case SpecialType.System_Single:
+                case SpecialType.System_Double:
+                case SpecialType.System_Decimal:
+                case SpecialType.System_Char:
+                case SpecialType.System_DateTime:
+                    return true;
+            }
+
+            if (underlying.ToDisplayString() is "System.DateTimeOffset" or "System.DateOnly" or "System.TimeOnly" or "System.TimeSpan")
+            {
+                return true;
+            }
+
+            // Types with a user-defined relational operator overload also work with Expression.GreaterThan/LessThan.
+            return underlying.GetMembers("op_GreaterThan").OfType<IMethodSymbol>().Any();
+        }
+
+        private static ITypeSymbol UnwrapNullable(ITypeSymbol type) =>
+            type is INamedTypeSymbol { OriginalDefinition.SpecialType: SpecialType.System_Nullable_T } nullableType
+                ? nullableType.TypeArguments[0]
+                : type;
+
+        // Resolves the constant int stored on the attribute back to the real ComparisonOperator member
+        // name, using the actual enum type (this project already references Abstractions), so the
+        // generated switch binds to the enum by name instead of duplicating its numeric layout by hand.
+        private static string ResolveComparisonOperatorName(int? comparisonOperator)
+        {
+            var value = comparisonOperator ?? (int)ComparisonOperator.Equal;
+
+            return Enum.IsDefined(typeof(ComparisonOperator), value)
+                ? ((ComparisonOperator)value).ToString()
+                : nameof(ComparisonOperator.Equal);
+        }
+
+        private static GenerationResult GenerateSource(PredicateCandidate candidate)
         {
             var namespaceName = candidate.FilterType!.ContainingNamespace.IsGlobalNamespace
                 ? null
@@ -166,6 +343,7 @@ namespace BlogDoFT.Libs.EntityFramework.CodeGenerator.Generators
             builder.AppendLine("using System;");
             builder.AppendLine("using System.Linq;");
             builder.AppendLine("using System.Linq.Expressions;");
+            builder.AppendLine("using BlogDoFT.Libs.EntityFramework.CodeGenerator.Abstractions.PredicateGenerators;");
             builder.AppendLine();
 
             builder.AppendLine($"partial class {filterTypeName}");
@@ -190,22 +368,22 @@ namespace BlogDoFT.Libs.EntityFramework.CodeGenerator.Generators
             builder.AppendLine("    }");
 
             builder.AppendLine();
-            builder.AppendLine("    private static Expression BuildComparison(Expression left, Expression right, int operatorValue)");
-            builder.AppendLine("    {");
-            builder.AppendLine("        switch (operatorValue)");
+            builder.AppendLine("    private static Expression BuildComparison(Expression left, Expression right, ComparisonOperator operatorValue) =>");
+            builder.AppendLine("        operatorValue switch");
             builder.AppendLine("        {");
-            builder.AppendLine("            case 0: return Expression.Equal(left, right);");
-            builder.AppendLine("            case 1: return Expression.GreaterThan(left, right);");
-            builder.AppendLine("            case 2: return Expression.LessThan(left, right);");
-            builder.AppendLine("            case 3: return Expression.GreaterThanOrEqual(left, right);");
-            builder.AppendLine("            case 4: return Expression.LessThanOrEqual(left, right);");
-            builder.AppendLine("            default: return Expression.Equal(left, right);");
-            builder.AppendLine("        }");
-            builder.AppendLine("    }");
+            builder.AppendLine("            ComparisonOperator.Equal => Expression.Equal(left, right),");
+            builder.AppendLine("            ComparisonOperator.GreaterThan => Expression.GreaterThan(left, right),");
+            builder.AppendLine("            ComparisonOperator.LessThan => Expression.LessThan(left, right),");
+            builder.AppendLine("            ComparisonOperator.GreaterThanOrEqual => Expression.GreaterThanOrEqual(left, right),");
+            builder.AppendLine("            ComparisonOperator.LessThanOrEqual => Expression.LessThanOrEqual(left, right),");
+            builder.AppendLine("        };");
 
             builder.AppendLine("}");
 
-            return builder.ToString();
+            return new GenerationResult(
+                source: builder.ToString(),
+                hasFilterableProperties: orderedFilters.Count > 0,
+                isInternal: methodAccessibility == "internal");
         }
 
         private static void AddHasFilterMethod(StringBuilder builder, string? methodAccessibility, List<FilterProperty> orderedFilters)
@@ -298,7 +476,8 @@ namespace BlogDoFT.Libs.EntityFramework.CodeGenerator.Generators
                 else if (filter.AttributeName == nameof(NumericFilterAttribute) || filter.AttributeName == nameof(TemporalFilterAttribute))
                 {
                     builder.AppendLine($"            var right = Expression.Convert(Expression.Constant(this.{sourcePropertyName}!), targetMember.Type);");
-                    builder.AppendLine($"            var comparison = BuildComparison(targetMember, right, {filter.ComparisonOperator ?? 0});");
+                    var operatorMemberName = ResolveComparisonOperatorName(filter.ComparisonOperator);
+                    builder.AppendLine($"            var comparison = BuildComparison(targetMember, right, ComparisonOperator.{operatorMemberName});");
                     builder.AppendLine("            aggregateBody = aggregateBody is null ? comparison : Expression.AndAlso(aggregateBody, comparison);");
                 }
                 else if (filter.AttributeName == nameof(BooleanFilterAttribute))
@@ -320,19 +499,40 @@ namespace BlogDoFT.Libs.EntityFramework.CodeGenerator.Generators
             builder.AppendLine("}");
         }
 
+        private readonly struct GenerationResult
+        {
+            public string Source { get; }
+            public bool HasFilterableProperties { get; }
+            public bool IsInternal { get; }
+
+            public GenerationResult(string source, bool hasFilterableProperties, bool isInternal)
+            {
+                Source = source;
+                HasFilterableProperties = hasFilterableProperties;
+                IsInternal = isInternal;
+            }
+        }
+
         private readonly struct PredicateCandidate
         {
             public INamedTypeSymbol? FilterType { get; }
             public INamedTypeSymbol? EntityType { get; }
             public bool IsPartial { get; }
             public IReadOnlyList<FilterProperty> Properties { get; }
+            public IReadOnlyList<Diagnostic> Diagnostics { get; }
 
-            public PredicateCandidate(INamedTypeSymbol? filterType, INamedTypeSymbol? entityType, bool isPartial, IReadOnlyList<FilterProperty> properties)
+            public PredicateCandidate(
+                INamedTypeSymbol? filterType,
+                INamedTypeSymbol? entityType,
+                bool isPartial,
+                IReadOnlyList<FilterProperty> properties,
+                IReadOnlyList<Diagnostic> diagnostics)
             {
                 FilterType = filterType;
                 EntityType = entityType;
                 IsPartial = isPartial;
                 Properties = properties;
+                Diagnostics = diagnostics;
             }
         }
 

--- a/src/BlogDoFT.Libs.WarmUp/Extensions/WarmUpServiceExtension.cs
+++ b/src/BlogDoFT.Libs.WarmUp/Extensions/WarmUpServiceExtension.cs
@@ -24,24 +24,17 @@ public static class WarmUpServiceExtension
 {
     /// <summary>
     /// Registers the warm-up health check and hosted service, using an <see cref="ILoggerFactory"/> resolved
-    /// from <paramref name="services"/> to log warm-up progress.
+    /// from the application's service provider (at DI-resolve time, not registration time) to log warm-up progress.
     /// </summary>
     /// <param name="services">The service collection to add the warm-up registrations to.</param>
     /// <returns>The same <see cref="IServiceCollection"/> instance, so calls can be chained.</returns>
     public static IServiceCollection AddWarmUp(
-        this IServiceCollection services)
-    {
-        using var provider = services.BuildServiceProvider();
-        using var scope = provider.CreateScope();
-        var logger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>()
-            .CreateLogger("WarmUp");
-
-        void LogInfo(string logInfo) => logger.LogInformation(logInfo);
-        void LogError(string logError) => logger.LogError(logError);
-        void LogTrace(string logTrace) => logger.LogTrace(logTrace);
-
-        return services.AddWarmUp(LogInfo, LogError, LogTrace);
-    }
+        this IServiceCollection services) =>
+        services
+            .AddSingleton<WarmUpHealthCheck>()
+            .AddHostedService<WarmUpHostedService>()
+            .ConfigureHealthCheck()
+            .AddWarmServices();
 
     /// <summary>
     /// Registers the warm-up health check and hosted service, using the supplied delegates to log warm-up progress.
@@ -125,5 +118,31 @@ public static class WarmUpServiceExtension
                 logError,
                 logTrace,
                 provider.GetRequiredService<WarmUpHealthCheck>()));
+
+    // Resolves the ILoggerFactory from the real provider each command is built with, at DI-resolve time
+    // (host startup), instead of building a throwaway provider from the still-being-configured collection.
+    private static IServiceCollection AddWarmServices(this IServiceCollection services) =>
+        services
+            .AddTransient(provider =>
+            {
+                var logger = provider.GetRequiredService<ILoggerFactory>().CreateLogger("WarmUp");
+                return new PreloadingCommand(
+                    services,
+                    provider,
+                    message => logger.LogInformation(message),
+                    message => logger.LogError(message),
+                    message => logger.LogTrace(message));
+            })
+            .AddTransient(provider =>
+            {
+                var logger = provider.GetRequiredService<ILoggerFactory>().CreateLogger("WarmUp");
+                return new WarmUpExecutor(
+                    services,
+                    provider,
+                    message => logger.LogInformation(message),
+                    message => logger.LogError(message),
+                    message => logger.LogTrace(message),
+                    provider.GetRequiredService<WarmUpHealthCheck>());
+            });
 }
 #pragma warning restore CA2254 // Template should be a static expression

--- a/src/BlogDoFT.Libs.WarmUp/Services/PreloadingCommand.cs
+++ b/src/BlogDoFT.Libs.WarmUp/Services/PreloadingCommand.cs
@@ -7,6 +7,7 @@ namespace BlogDoFT.Libs.WarmUp.Services;
 internal class PreloadingCommand : BaseWarmCommand
 {
     private const string LogMessage = "Pre-loading: {0}.";
+    private const string LogErrorMessage = "Error when pre-loading {0}: {1}";
     private const string PreloadingStart = "Preloading services.";
     private const string PreloadingEnd = "Preloading services finished.";
 
@@ -23,19 +24,23 @@ internal class PreloadingCommand : BaseWarmCommand
     public override Task Execute()
     {
         LogInfo(PreloadingStart);
-        Task.Run(() =>
+        using var scope = Provider.CreateScope();
+        foreach (var type in GetServices())
         {
-            using var scope = Provider.CreateScope();
-            foreach (var type in GetServices())
+            try
             {
                 scope.ServiceProvider.GetServices(type);
 
                 var logMessage = string.Format(LogMessage, type.FullName);
                 LogTrace(logMessage);
             }
+            catch (Exception exception)
+            {
+                LogError(string.Format(LogErrorMessage, type.FullName, exception.Message));
+            }
+        }
 
-            LogInfo(PreloadingEnd);
-        });
+        LogInfo(PreloadingEnd);
 
         return Task.CompletedTask;
     }

--- a/src/BlogDoFT.Libs.WarmUp/Services/WarmUpExecutor.cs
+++ b/src/BlogDoFT.Libs.WarmUp/Services/WarmUpExecutor.cs
@@ -23,29 +23,24 @@ internal class WarmUpExecutor : BaseWarmCommand
         _warmUpHealthCheck = warmUpHealthCheck;
     }
 
-    public override Task Execute()
+    public override async Task Execute()
     {
         LogInfo("Executing warmup.");
-        Task.Run(async () =>
+        using var scope = Provider.CreateScope();
+        foreach (var type in GetCommands())
         {
-            using var scope = Provider.CreateScope();
-            foreach (var type in GetCommands())
+            if (scope.ServiceProvider.GetRequiredService(type) is not IWarmUpCommand warmUpCommand)
             {
-                if (scope.ServiceProvider.GetRequiredService(type) is not IWarmUpCommand warmUpCommand)
-                {
-                    continue;
-                }
-
-                await ExecuteWarmingUpAsync(warmUpCommand);
-                var logMessage = string.Format(LogMessage, warmUpCommand.GetType().FullName);
-                LogTrace(logMessage);
+                continue;
             }
 
-            _warmUpHealthCheck.WarmUpCompleted = true;
-            LogInfo("Warmup finished.");
-        });
+            await ExecuteWarmingUpAsync(warmUpCommand);
+            var logMessage = string.Format(LogMessage, warmUpCommand.GetType().FullName);
+            LogTrace(logMessage);
+        }
 
-        return Task.CompletedTask;
+        _warmUpHealthCheck.WarmUpCompleted = true;
+        LogInfo("Warmup finished.");
     }
 
     private IEnumerable<Type> GetCommands() =>


### PR DESCRIPTION
## Summary
Bundles the fixes for issues found in a solution-wide architecture review (see `analysis.md`, added in this branch):

- **WarmUp sequencing**: `WarmUpExecutor.Execute()`/`PreloadingCommand.Execute()` returned `Task.CompletedTask` while the real work ran in a detached, unawaited `Task.Run`, so `WarmUpHostedService`'s sequential `await` didn't actually sequence preloading before warm-up. Both now return the real completing `Task`; `PreloadingCommand` also gained per-service exception handling.
- **WarmUp DI registration**: `AddWarmUp()` built a throwaway `IServiceProvider` from the still-being-configured `IServiceCollection` (ASP0000 anti-pattern) just to resolve an `ILoggerFactory`. Resolution is now deferred to DI-resolve time, using the real, fully configured provider.
- **Postgres connection laziness**: `PostgresDatabaseFacade` opened its connection with a blocking `Open()` in the constructor; since it's `Scoped`, every DI scope paid for a synchronous network round-trip regardless of use. The connection now opens lazily via `OpenAsync` on first real use; `GetDbConnection()` still guarantees an already-open connection for callers relying on that contract.
- **EF predicate generator diagnostics**: 9 diagnostic descriptors existed but only 1 was ever reported — invalid usage (unresolved entity type, invalid `TargetProperty` path, unsupported filter attribute, an operator that doesn't apply to the target member's type) silently produced wrong or dead generated code. All descriptors are now wired up (PG002/003/004/005/010/101), invalid filters are excluded from generation instead of compiling into broken runtime behavior, and the whole pipeline is wrapped so an unexpected exception reports PG900 instead of crashing the consumer's build.
- **EF predicate generator operator binding**: the generated `BuildComparison` switch mapped `ComparisonOperator` by raw int literal, disconnected from the real enum — reordering/inserting a member would silently reinterpret existing DTOs' operators. The switch now matches by enum member name, so it stays correct across reorders and the compiler flags a non-exhaustive switch if a new member is added.
- Added a new `BlogDoFT.Libs.EntityFramework.CodeGenerator.Tests` project (none existed before) that drives the generator in-memory via `CSharpGeneratorDriver`, plus regression tests for the WarmUp DI-registration fix and the Postgres facade's lazy connection.
- Minor cleanup: removed two redundant null-forgiving operators (SonarAnalyzer S8969).

## Test plan
- [x] `dotnet build BlogDoFT.Libs.sln` — succeeds, 0 errors, only pre-existing unrelated warnings
- [x] `dotnet test BlogDoFT.Libs.sln` — all 121 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)